### PR TITLE
feat(gpkg): Tile layers now use reprojection/stitching

### DIFF
--- a/externs/geopackage.js
+++ b/externs/geopackage.js
@@ -1,3 +1,4 @@
+/* eslint-disable opensphere/no-unused-vars */
 /**
  * @fileoverview Externs for interacting with src/worker/gpkg.worker.js
  * @externs
@@ -9,9 +10,14 @@
  *  id: !string,
  *  type: !string,
  *  data: (ArrayBuffer|Object|undefined),
+ *  extent: (ol.Extent|undefined),
+ *  projection: (string|undefined),
  *  tileCoord: (Array<number>|undefined),
  *  tableName: (string|undefined),
  *  url: (string|undefined),
+ *  height: (number|undefined),
+ *  width: (number|undefined),
+ *  zoom: (number|undefined),
  *  columns: ({field: string, type: string}|undefined),
  *  command: (string|undefined)
  * }}

--- a/index.js
+++ b/index.js
@@ -49,7 +49,11 @@ module.exports = {
     }, {
       source: resolver.resolveModulePath('@ngageoint/geopackage/dist'),
       target: 'vendor/geopackage',
-      files: ['geopackage.min.js']
+      files: [
+        'geopackage.min.js',
+        'sql-wasm.wasm',
+        'canvaskit/canvaskit.wasm'
+      ]
     }]
   }],
   debugCss: path.relative(__dirname, path.join(buildPath, 'combined.css')),

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,6 +49,8 @@ module.exports = function(config) {
       {pattern: resolver.resolveModulePath('d3/d3.min.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('jsts/dist/jsts.min.js', __dirname), watched: false, included: true, served: true},
       {pattern: resolver.resolveModulePath('@ngageoint/geopackage/dist/geopackage.min.js', __dirname), watched: false, included: false, served: true},
+      {pattern: resolver.resolveModulePath('@ngageoint/geopackage/dist/sql-wasm.wasm', __dirname), watched: false, included: false, served: true},
+      {pattern: resolver.resolveModulePath('@ngageoint/geopackage/dist/canvaskit/canvaskit.wasm', __dirname), watched: false, included: false, served: true},
 
       // test resources
       {pattern: 'test/resources/**/*', included: false},

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "semantic-release": "^15.13.32"
   },
   "dependencies": {
-    "@ngageoint/geopackage": "^4.0.0-beta.28",
+    "@ngageoint/geopackage": "^4.0.0-beta.29",
     "better-sqlite3": "7.1.4",
     "nan": "2.14.0",
     "opensphere": "0.0.0-development"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "semantic-release": "^15.13.32"
   },
   "dependencies": {
-    "@ngageoint/geopackage": "^2.0.0",
+    "@ngageoint/geopackage": "^4.0.0-beta.28",
+    "better-sqlite3": "7.1.4",
     "nan": "2.14.0",
     "opensphere": "0.0.0-development"
   },

--- a/src/plugin/geopackage/geopackagetilelayerconfig.js
+++ b/src/plugin/geopackage/geopackagetilelayerconfig.js
@@ -2,11 +2,17 @@ goog.module('plugin.geopackage.TileLayerConfig');
 
 const GoogEventType = goog.require('goog.events.EventType');
 const log = goog.require('goog.log');
+const {DEFAULT_MAX_ZOOM} = goog.require('ol');
 const ImageTile = goog.require('ol.ImageTile');
 const TileState = goog.require('ol.TileState');
+const {transformExtent} = goog.require('ol.proj');
 const TileImage = goog.require('ol.source.TileImage');
+const {createForProjection} = goog.require('ol.tilegrid');
 const TileGrid = goog.require('ol.tilegrid.TileGrid');
+const osMap = goog.require('os.map');
+const {EPSG4326} = goog.require('os.proj');
 const AbstractTileLayerConfig = goog.require('os.layer.config.AbstractTileLayerConfig');
+const {ID_DELIMITER} = goog.require('os.ui.data.BaseProvider');
 const {MsgType, getWorker} = goog.require('plugin.geopackage');
 const Tile = goog.require('plugin.geopackage.Tile');
 
@@ -59,21 +65,26 @@ class TileLayerConfig extends AbstractTileLayerConfig {
    * @inheritDoc
    */
   getSource(options) {
-    const parts = options['id'].split(os.ui.data.BaseProvider.ID_DELIMITER);
+    const parts = options['id'].split(ID_DELIMITER);
+
+    const gpkgTileGrid = new TileGrid(/** @type {olx.tilegrid.TileGridOptions} */ ({
+      'extent': options.extent,
+      'minZoom': Math.max(0, Math.round(options['gpkgMinZoom'])),
+      'resolutions': options['resolutions'],
+      'tileSizes': options['tileSizes']
+    }));
+
+    const layerTileGrid = createForProjection(osMap.PROJECTION, DEFAULT_MAX_ZOOM, [256, 256]);
 
     const source = new TileImage(/** @type {olx.source.TileImageOptions} */ ({
       'projection': this.projection,
-      'tileLoadFunction': getTileLoadFunction(parts[0]),
+      'tileLoadFunction': getTileLoadFunction(parts[0], gpkgTileGrid, layerTileGrid),
       'tileUrlFunction': getTileUrlFunction(parts[1]),
-      'tileGrid': new TileGrid(/** @type {olx.tilegrid.TileGridOptions} */ ({
-        'extent': options.extent,
-        'minZoom': Math.max(0, Math.round(options['minZoom'])),
-        'resolutions': options['resolutions'],
-        'tileSizes': options['tileSizes']
-      })),
+      'tileGrid': layerTileGrid,
       'wrapX': this.projection.isGlobal()
     }));
 
+    source.setExtent(options.extent);
     addTileListener();
     return source;
   }
@@ -82,9 +93,11 @@ class TileLayerConfig extends AbstractTileLayerConfig {
 
 /**
  * @param {string} providerId
+ * @param {ol.tilegrid.TileGrid} gpkgTileGrid
+ * @param {ol.tilegrid.TileGrid} tileGrid
  * @return {!ol.TileLoadFunctionType}
  */
-const getTileLoadFunction = (providerId) => (
+const getTileLoadFunction = (providerId, gpkgTileGrid, tileGrid) => (
   /**
    * @param {ol.Tile} tile The image tile
    * @param {string} layerName The layer name
@@ -98,14 +111,25 @@ const getTileLoadFunction = (providerId) => (
     }
 
     if (layerName) {
+      const tileCoord = imageTile.getTileCoord();
+      let extent = tileGrid.getTileCoordExtent(tileCoord);
+      extent = transformExtent(extent, osMap.PROJECTION, EPSG4326);
+      const layerResolution = tileGrid.getResolution(tileCoord[0]);
+      const gpkgZoom = gpkgTileGrid.getZForResolution(layerResolution);
+      const size = tileGrid.getTileSize(tileCoord[0]);
+
       const msg = /** @type {GeoPackageWorkerMessage} */ ({
         id: providerId,
         type: MsgType.GET_TILE,
         tableName: layerName,
-        tileCoord: imageTile.getTileCoord()
+        projection: osMap.PROJECTION.getCode(),
+        extent: extent,
+        zoom: gpkgZoom,
+        width: size[0],
+        height: size[1]
       });
 
-      const key = msg.id + '#' + msg.type + '#' + msg.tableName + '#' + msg.tileCoord.join(',');
+      const key = msg.id + '#' + msg.type + '#' + msg.tableName + '#' + msg.extent.join(',');
       tiles[key] = imageTile;
       getWorker().postMessage(msg);
     }
@@ -135,7 +159,7 @@ const tileListener = (evt) => {
       msg.message.id,
       msg.message.type,
       msg.message.tableName,
-      msg.message.tileCoord.join(',')
+      (msg.message.tileCoord || msg.message.extent).join(',')
     ].join('#');
 
     const imageTile = tiles[key];

--- a/src/worker/gpkg.worker.js
+++ b/src/worker/gpkg.worker.js
@@ -285,8 +285,8 @@ var listDescriptors = function(msg) {
             type: 'geopackage-tile',
             title: info.tableName,
             tableName: info.tableName,
-            minZoom: Math.round(info.minZoom),
-            maxZoom: Math.round(info.maxZoom),
+            gpkgMinZoom: Math.round(info.minZoom),
+            gpkgMaxZoom: Math.round(info.maxZoom),
             resolutions: fixResolutions(tileMatrices.map(getTileMatrixToResolutionMapper(info))),
             tileSizes: fixSizes(tileMatrices.map(tileMatrixToTileSize))
           };
@@ -363,33 +363,54 @@ var getTile = function(msg) {
     return;
   }
 
-  if (!msg.tileCoord) {
-    handleError('tileCoord property must be set', msg);
+  if (msg.zoom == null) {
+    handleError('zoom property must be set', msg);
     return;
   }
 
-  if (msg.tileCoord.length !== 3) {
-    handleError('tileCoord [z, x, y] must have a length of exactly 3', msg);
+  if (!msg.projection) {
+    handleError('projection property must be set', msg);
+    return;
+  }
+
+  if (!msg.width) {
+    handleError('width property must be set', msg);
+    return;
+  }
+
+  if (!msg.height) {
+    handleError('height property must be set', msg);
+    return;
+  }
+
+  if (!msg.extent) {
+    handleError('extent (ol.Extent in EPSG:4326) property must be set', msg);
     return;
   }
 
   try {
     var tileDao = gpkg.getTileDao(msg.tableName);
-    var tile = tileDao.queryForTile(msg.tileCoord[1], -msg.tileCoord[2] - 1, msg.tileCoord[0]);
+    var bbox = new geopackage.BoundingBox(msg.extent[0], msg.extent[2], msg.extent[1], msg.extent[3]);
+    var ret = new geopackage.GeoPackageTileRetriever(tileDao, msg.width, msg.height);
+    ret.getTileWithWgs84BoundsInProjection(bbox, msg.zoom, msg.projection)
+        .then(function(tile) {
+          if (!tile) {
+            success(msg);
+            return;
+          }
 
-    if (!tile) {
-      success(msg);
-      return;
-    }
+          var array = tile instanceof Buffer ? tile : tile.getTileData();
 
-    var array = tile.getTileData();
-
-    if (isNode) {
-      success(msg, Array.from(new Int32Array(array)));
-    } else {
-      var blob = new Blob([array]);
-      success(msg, URL.createObjectURL(blob));
-    }
+          if (isNode) {
+            success(msg, Array.from(new Int32Array(array)));
+          } else {
+            var blob = new Blob([array]);
+            success(msg, URL.createObjectURL(blob));
+          }
+        })
+        .catch(function(err) {
+          handleError(err, msg);
+        });
   } catch (e) {
     handleError(e, msg);
   }

--- a/test/plugin/geopackage/geopackageprovider.test.js
+++ b/test/plugin/geopackage/geopackageprovider.test.js
@@ -49,8 +49,8 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
         title: 'byte_jpeg',
         layerType: os.layer.LayerType.TILES,
         icons: os.ui.Icons.TILES,
-        minZoom: 0,
-        maxZoom: 0,
+        gpkgMinZoom: 0,
+        gpkgMaxZoom: 0,
         projection: 'EPSG:26711',
         extentProjection: 'EPSG:26711',
         extent: [440720, 3735960, 456080, 3751320]
@@ -59,8 +59,8 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
         title: 'byte_png',
         layerType: os.layer.LayerType.TILES,
         icons: os.ui.Icons.TILES,
-        minZoom: 0,
-        maxZoom: 0,
+        gpkgMinZoom: 0,
+        gpkgMaxZoom: 0,
         projection: 'EPSG:26711',
         extentProjection: 'EPSG:26711',
         extent: [440720, 3735960, 456080, 3751320]
@@ -154,7 +154,7 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
         expect(config.delayUpdateActive).toBe(true);
 
         for (var key in expected[i]) {
-          expect(config[key]).toEqual(expected[i][key]);
+          expect(config[key]).toEqual(expected[i][key], `${key}`);
         }
       }
     });


### PR DESCRIPTION
**Note:** This PR was moved from https://github.com/wallw-bits/opensphere-plugin-geopackage/pull/2 and updated to the latest changes on `master`.

Use the reprojection support in geopackage-js to allow the OpenSphere side to use a more typical XYZ grid with an extent and have geopackage-js stitch and resample the new tiles together. This allows better support from Cesium (especially for different origins per tile matrix), in addition to showing the raster layer in more resolutions than what may be defined in the GeoPackage (resulting in a better user experience).

Note: "reprojection" is an odd word here. By default, OpenSphere will still enforce the reprojection flag in config. In this case, GeoPackages in the application projection will simply be restitched/resampled into other tiles, but not reprojected. GeoPackages in another projection will ask the user to switch to that projection, just like all of our other layers.

Caveat:
The jpeg-js library that geopackage-js uses has some issues with some JPEG color support that the native browser JPEG library does not. For some GeoPackages I tested, I received the error:
```
Unsupported color mode (4 components)
```
I'm not sure if that is something that is incorrect from a JPEG-spec perspective and the browser native library is simply ignoring it, or if it is indicative of a lack of support for a feature in jpeg-js.