### PR TITLE
refactor(goog): transform source to use goog.module

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,12 +21,17 @@ module.exports = function(config) {
   const gpkg = resolver.resolveModulePath('@ngageoint/geopackage/dist/geopackage.min.js', __dirname);
   const gpkgDefinePath = path.join(__dirname, '.build', 'gpkg-define.js');
   const gpkgManifestPath = path.join(__dirname, '.build', 'gcc-test-manifest-gpkg');
-  fs.writeFileSync(gpkgDefinePath, 'plugin.geopackage.GPKG_PATH = "/absolute' + gpkg + '"');
+  const gpkgDefineSrc = `
+    var CLOSURE_UNCOMPILED_DEFINES = {
+      'plugin.geopackage.GPKG_PATH': '/absolute${gpkg}',
+      'plugin.geopackage.ROOT': 'base/'
+    }`.trim();
+  fs.writeFileSync(gpkgDefinePath, gpkgDefineSrc);
 
   // add the file to the test manifest
   const testManifest = fs.readFileSync('.build/gcc-test-manifest', 'utf8').trim();
   if (testManifest.indexOf(gpkgDefinePath) === -1) {
-    fs.writeFileSync(gpkgManifestPath, `${testManifest}\n${gpkgDefinePath}`);
+    fs.writeFileSync(gpkgManifestPath, `${gpkgDefinePath}\n${testManifest}`);
   }
 
   config.set({

--- a/src/plugin/geopackage/geopackage.js
+++ b/src/plugin/geopackage/geopackage.js
@@ -1,38 +1,37 @@
-goog.provide('plugin.geopackage');
+goog.module('plugin.geopackage');
 
-goog.require('goog.log');
+const log = goog.require('goog.log');
 
-
-/**
- * @define {string}
- */
-plugin.geopackage.ROOT = goog.define('plugin.geopackage.ROOT', '../opensphere-plugin-geopackage/');
 
 /**
  * @define {string}
  */
-plugin.geopackage.GPKG_PATH = goog.define('plugin.geopackage.GPKG_PATH', 'vendor/geopackage/geopackage.min.js');
+exports.ROOT = goog.define('plugin.geopackage.ROOT', '../opensphere-plugin-geopackage/');
+
+/**
+ * @define {string}
+ */
+exports.GPKG_PATH = goog.define('plugin.geopackage.GPKG_PATH', 'vendor/geopackage/geopackage.min.js');
 
 /**
  * @type {string}
  * @const
  */
-plugin.geopackage.ID = 'geopackage';
+exports.ID = 'geopackage';
 
 
 /**
  * The logger.
  * @const
  * @type {goog.debug.Logger}
- * @private
  */
-plugin.geopackage.LOGGER = goog.log.getLogger('plugin.geopackage');
+const LOGGER = log.getLogger('plugin.geopackage');
 
 
 /**
  * @enum {string}
  */
-plugin.geopackage.MsgType = {
+exports.MsgType = {
   OPEN_LIBRARY: 'openLibrary',
   OPEN: 'open',
   CLOSE: 'close',
@@ -47,7 +46,7 @@ plugin.geopackage.MsgType = {
 /**
  * @enum {string}
  */
-plugin.geopackage.ExportCommands = {
+exports.ExportCommands = {
   CREATE: 'create',
   CREATE_TABLE: 'createTable',
   GEOJSON: 'geojson',
@@ -59,16 +58,15 @@ plugin.geopackage.ExportCommands = {
 
 /**
  * @type {?Worker}
- * @private
  */
-plugin.geopackage.worker_ = null;
+let worker_ = null;
 
 
 /**
  * Get the Electron preload exports.
  * @return {Object|undefined}
  */
-plugin.geopackage.getElectron = function() {
+exports.getElectron = () => {
   return window.ElectronGpkg || undefined;
 };
 
@@ -77,19 +75,19 @@ plugin.geopackage.getElectron = function() {
  * If the app is running within Electron.
  * @return {boolean}
  */
-plugin.geopackage.isElectron = function() {
-  return !!plugin.geopackage.getElectron();
+exports.isElectron = () => {
+  return !!exports.getElectron();
 };
 
 
 /**
  * @return {!Worker} The GeoPackage worker
  */
-plugin.geopackage.getWorker = function() {
-  if (!plugin.geopackage.worker_) {
-    var src = plugin.geopackage.ROOT + 'src/worker/gpkg.worker.js';
+exports.getWorker = () => {
+  if (!worker_) {
+    let src = exports.ROOT + 'src/worker/gpkg.worker.js';
 
-    var electron = plugin.geopackage.getElectron();
+    const electron = exports.getElectron();
     if (electron) {
       // The node context (as opposed to the electron browser context), loads
       // paths relative to process.cwd(). Therefore, we need to make our source
@@ -108,7 +106,7 @@ plugin.geopackage.getWorker = function() {
       // than node bindings.
       //
       // see associated hack in gpkg.worker.js
-      var options = electron.getElectronEnvOptions();
+      const options = electron.getElectronEnvOptions();
 
       // to debug this guy:
       //  - open chrome://inspect/#devices
@@ -120,18 +118,18 @@ plugin.geopackage.getWorker = function() {
       // DEBUG VERSION! Do not commit next line uncommented
       // options['execArgv'] = ['--inspect-brk'];
 
-      plugin.geopackage.worker_ = /** @type {!Worker} */ (electron.forkProcess(src, [], options));
+      worker_ = (electron.forkProcess(src, [], options));
 
-      goog.log.info(plugin.geopackage.LOGGER, 'GeoPackage worker configured via node child process');
+      log.info(LOGGER, 'GeoPackage worker configured via node child process');
     } else {
-      plugin.geopackage.worker_ = new Worker(src);
-      plugin.geopackage.worker_.postMessage(/** @type {GeoPackageWorkerMessage} */ ({
-        type: plugin.geopackage.MsgType.OPEN_LIBRARY,
-        url: (!plugin.geopackage.GPKG_PATH.startsWith('/') ? '../../' : '') + plugin.geopackage.GPKG_PATH
+      worker_ = new Worker(src);
+      worker_.postMessage(/** @type {GeoPackageWorkerMessage} */ ({
+        type: exports.MsgType.OPEN_LIBRARY,
+        url: (!exports.GPKG_PATH.startsWith('/') ? '../../' : '') + exports.GPKG_PATH
       }));
-      goog.log.info(plugin.geopackage.LOGGER, 'GeoPackage worker configured via web worker');
+      log.info(LOGGER, 'GeoPackage worker configured via web worker');
     }
   }
 
-  return plugin.geopackage.worker_;
+  return worker_;
 };

--- a/src/plugin/geopackage/geopackageimportui.js
+++ b/src/plugin/geopackage/geopackageimportui.js
@@ -1,96 +1,95 @@
-goog.provide('plugin.geopackage.GeoPackageImportUI');
+goog.module('plugin.geopackage.GeoPackageImportUI');
 
-goog.require('os.alert.AlertEventSeverity');
-goog.require('os.file');
-goog.require('os.file.FileStorage');
-goog.require('os.ui.im.AbstractImportUI');
-goog.require('os.ui.menu.windows');
-goog.require('plugin.geopackage');
-goog.require('plugin.geopackage.GeoPackageProvider');
+const AlertManager = goog.require('os.alert.AlertManager');
+const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
+const {isLocal, FILE_URL_ENABLED} = goog.require('os.file');
+const FileStorage = goog.require('os.file.FileStorage');
+const AbstractImportUI = goog.require('os.ui.im.AbstractImportUI');
+const windows = goog.require('os.ui.menu.windows');
+const geopackage = goog.require('plugin.geopackage');
+const GeoPackageProvider = goog.require('plugin.geopackage.GeoPackageProvider');
 
-/**
- * @constructor
- * @extends {os.ui.im.AbstractImportUI}
- */
-plugin.geopackage.GeoPackageImportUI = function() {
-  /**
-   * @type {boolean}
-   */
-  this.requiresStorage = !os.file.FILE_URL_ENABLED;
-
-  /**
-   * @type {os.file.File}
-   * @protected
-   */
-  this.file = null;
-};
-goog.inherits(plugin.geopackage.GeoPackageImportUI, os.ui.im.AbstractImportUI);
+const OSFile = goog.requireType('os.file.File');
 
 
 /**
- * @inheritDoc
  */
-plugin.geopackage.GeoPackageImportUI.prototype.launchUI = function(file, opt_config) {
-  if (file) {
-    this.file = file;
-    var url = file.getUrl();
+class GeoPackageImportUI extends AbstractImportUI {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.requiresStorage = !FILE_URL_ENABLED;
 
-    // see if there are any other geopackage providers for the same file
-    var list = os.dataManager.getProviderRoot().getChildren().filter(function(provider) {
-      return provider instanceof plugin.geopackage.GeoPackageProvider && provider.getUrl() === url;
-    });
+    /**
+     * @type {OSFile}
+     * @protected
+     */
+    this.file = null;
+  }
 
-    if (list.length) {
-      list.forEach(function(provider) {
-        provider.load();
-      });
+  /**
+   * @inheritDoc
+   */
+  launchUI(file, opt_config) {
+    if (file) {
+      this.file = file;
+      const url = file.getUrl();
 
-      os.alertManager.sendAlert(file.getFileName() + ' GeoPackage refreshed',
-          os.alert.AlertEventSeverity.INFO);
-    } else if (os.file.isLocal(file)) {
-      os.file.FileStorage.getInstance().storeFile(file, true).addCallbacks(
-          this.onFileReady, this.onFileError, this);
-    } else {
-      this.onFileReady();
+      // see if there are any other geopackage providers for the same file
+      const list = os.dataManager.getProviderRoot().getChildren()
+          .filter((provider) => provider instanceof GeoPackageProvider && provider.getUrl() === url);
+
+      if (list.length) {
+        list.forEach((provider) => {
+          provider.load();
+        });
+
+        AlertManager.getInstance().sendAlert(`${file.getFileName()} GeoPackage refreshed`, AlertEventSeverity.INFO);
+      } else if (isLocal(file)) {
+        FileStorage.getInstance().storeFile(file, true).addCallbacks(this.onFileReady, this.onFileError, this);
+      } else {
+        this.onFileReady();
+      }
     }
   }
-};
 
+  /**
+   * @protected
+   */
+  onFileReady() {
+    const file = this.file;
+    const conf = {
+      'type': geopackage.ID,
+      'label': file.getFileName(),
+      'url': file.getUrl()
+    };
 
-/**
- * @protected
- */
-plugin.geopackage.GeoPackageImportUI.prototype.onFileReady = function() {
-  var file = this.file;
-  var conf = {
-    'type': plugin.geopackage.ID,
-    'label': file.getFileName(),
-    'url': file.getUrl()
-  };
+    const provider = new GeoPackageProvider();
+    provider.configure(conf);
+    provider.setId(goog.string.getRandomString());
+    provider.setEnabled(true);
+    provider.setEditable(true);
+    provider.load();
 
-  var provider = new plugin.geopackage.GeoPackageProvider();
-  provider.configure(conf);
-  provider.setId(goog.string.getRandomString());
-  provider.setEnabled(true);
-  provider.setEditable(true);
-  provider.load();
+    os.settings.set(['userProviders', provider.getId()], conf);
+    os.dataManager.addProvider(provider);
 
-  os.settings.set(['userProviders', provider.getId()], conf);
-  os.dataManager.addProvider(provider);
+    AlertManager.getInstance().sendAlert(`${file.getFileName()} GeoPackage added!`, AlertEventSeverity.INFO);
 
-  os.alertManager.sendAlert(file.getFileName() + ' GeoPackage added!',
-      os.alert.AlertEventSeverity.INFO);
+    windows.openWindow('addData');
+    this.file = null;
+  }
 
-  os.ui.menu.windows.openWindow('addData');
-  this.file = null;
-};
+  /**
+   * @param {*=} opt_reason
+   * @protected
+   */
+  onFileError(opt_reason) {
+    AlertManager.getInstance().sendAlert(`Error adding GeoPackage. ${opt_reason}`);
+    this.file = null;
+  }
+}
 
-
-/**
- * @param {*=} opt_reason
- * @protected
- */
-plugin.geopackage.GeoPackageImportUI.prototype.onFileError = function(opt_reason) {
-  os.alertManager.sendAlert('Error adding GeoPackage. ' + opt_reason);
-  this.file = null;
-};
+exports = GeoPackageImportUI;

--- a/src/plugin/geopackage/geopackagerequesthandler.js
+++ b/src/plugin/geopackage/geopackagerequesthandler.js
@@ -1,221 +1,213 @@
-goog.provide('plugin.geopackage.RequestHandler');
+goog.module('plugin.geopackage.RequestHandler');
 
-goog.require('goog.events.EventTarget');
-goog.require('goog.log');
-goog.require('goog.log.Logger');
-goog.require('os.net.IRequestHandler');
+const EventTarget = goog.require('goog.events.EventTarget');
+const GoogEventType = goog.require('goog.events.EventType');
+const log = goog.require('goog.log');
+const NetEventType = goog.require('goog.net.EventType');
+const {getWorker, MsgType, ID} = goog.require('plugin.geopackage');
 
-
-/**
- * @constructor
- * @extends {goog.events.EventTarget}
- * @implements {os.net.IRequestHandler}
- */
-plugin.geopackage.RequestHandler = function() {
-  plugin.geopackage.RequestHandler.base(this, 'constructor');
-
-  this.log = plugin.geopackage.RequestHandler.LOGGER_;
-
-  /**
-   * @type {number}
-   * @protected
-   */
-  this.statusCode = -1;
-
-  /**
-   * @type {Array<string>}
-   * @protected
-   */
-  this.errors = [];
-
-  /**
-   * @type {Array<Object>}
-   * @protected
-   */
-  this.features = null;
-
-  /**
-   * @private
-   */
-  this.workerHandler_ = this.onMessage.bind(this);
-
-  /**
-   * @type {string}
-   * @protected
-   */
-  this.lastId = '';
-
-  /**
-   * @type {string}
-   * @protected
-   */
-  this.lastTableName = '';
-};
-goog.inherits(plugin.geopackage.RequestHandler, goog.events.EventTarget);
+const Logger = goog.requireType('goog.log.Logger');
+const IRequestHandler = goog.requireType('os.net.IRequestHandler');
 
 
 /**
  * Logger
- * @type {goog.log.Logger}
- * @const
- * @private
+ * @type {Logger}
  */
-plugin.geopackage.RequestHandler.LOGGER_ = goog.log.getLogger('plugin.geopackage.RequestHandler');
+const LOGGER = log.getLogger('plugin.geopackage.RequestHandler');
 
 
 /**
- * @inheritDoc
+ * @implements {IRequestHandler}
  */
-plugin.geopackage.RequestHandler.prototype.disposeInternal = function() {
-  var worker = plugin.geopackage.getWorker();
-  worker.removeEventListener(goog.events.EventType.MESSAGE, this.workerHandler_);
-  plugin.geopackage.RequestHandler.base(this, 'disposeInternal');
-};
+class RequestHandler extends EventTarget {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+
+    this.log = LOGGER;
+
+    /**
+     * @type {number}
+     * @protected
+     */
+    this.statusCode = -1;
+
+    /**
+     * @type {Array<string>}
+     * @protected
+     */
+    this.errors = [];
+
+    /**
+     * @type {Array<Object>}
+     * @protected
+     */
+    this.features = null;
+
+    /**
+     * @private
+     */
+    this.workerHandler_ = this.onMessage.bind(this);
+
+    /**
+     * @type {string}
+     * @protected
+     */
+    this.lastId = '';
+
+    /**
+     * @type {string}
+     * @protected
+     */
+    this.lastTableName = '';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    const worker = getWorker();
+    worker.removeEventListener(GoogEventType.MESSAGE, this.workerHandler_);
+    super.disposeInternal();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getScore() {
+    return 100;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handles(method, uri) {
+    return uri.getScheme() === 'gpkg';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getResponse() {
+    return this.features;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getResponseHeaders() {
+    return null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getTimeout() {
+    return 0;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  setTimeout(value) {
+    // not supported
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getErrors() {
+    return this.errors.length ? this.errors : null;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getStatusCode() {
+    return this.statusCode;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getHandlerType() {
+    return ID;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  isHandled() {
+    return true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  buildRequest() {}
 
 
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.getScore = function() {
-  return 100;
-};
+  /**
+   * @inheritDoc
+   */
+  abort() {}
 
+  /**
+   * @inheritDoc
+   */
+  execute(method, uri, opt_headers, opt_formatter, opt_nocache, opt_responseType) {
+    const worker = getWorker();
+    worker.addEventListener(GoogEventType.MESSAGE, this.workerHandler_);
 
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.handles = function(method, uri) {
-  return uri.getScheme() === 'gpkg';
-};
+    this.lastId = uri.getDomain();
+    this.lastTableName = uri.getPath().substring(1);
 
+    worker.postMessage(/** @type {GeoPackageWorkerMessage} */ ({
+      id: this.lastId,
+      type: MsgType.GET_FEATURES,
+      tableName: this.lastTableName
+    }));
+  }
 
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.getResponse = function() {
-  return this.features;
-};
+  /**
+   * @param {Event|GeoPackageWorkerResponse} e
+   * @protected
+   */
+  onMessage(e) {
+    const msg = /** @type {GeoPackageWorkerResponse} */ (e instanceof window.Event ? e.data : e);
 
+    if (msg.message.id === this.lastId && msg.message.tableName === this.lastTableName) {
+      const worker = getWorker();
 
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.getResponseHeaders = function() {
-  return null;
-};
+      if (msg.type === MsgType.SUCCESS) {
+        if (msg.data === 0) {
+          // finished
+          worker.removeEventListener(GoogEventType.MESSAGE, this.workerHandler_);
+          this.dispatchEvent(NetEventType.SUCCESS);
+        } else if (msg.data) {
+          if ('geometry' in msg.data['properties']) {
+            // this will really screw up the resulting feature
+            delete msg.data['properties']['geometry'];
+          }
 
+          if (!this.features) {
+            this.features = [];
+          }
 
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.getTimeout = function() {
-  return 0;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.setTimeout = function(value) {
-  // not supported
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.getErrors = function() {
-  return this.errors.length ? this.errors : null;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.getStatusCode = function() {
-  return this.statusCode;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.getHandlerType = function() {
-  return plugin.geopackage.ID;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.isHandled = function() {
-  return true;
-};
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.buildRequest = goog.nullFunction;
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.abort = goog.nullFunction;
-
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.RequestHandler.prototype.execute = function(method, uri, opt_headers, opt_formatter,
-    opt_nocache, opt_responseType) {
-  var worker = plugin.geopackage.getWorker();
-  worker.addEventListener(goog.events.EventType.MESSAGE, this.workerHandler_);
-
-  this.lastId = uri.getDomain();
-  this.lastTableName = uri.getPath().substring(1);
-
-  worker.postMessage(/** @type {GeoPackageWorkerMessage} */ ({
-    id: this.lastId,
-    type: plugin.geopackage.MsgType.GET_FEATURES,
-    tableName: this.lastTableName
-  }));
-};
-
-
-/**
- * @param {Event|GeoPackageWorkerResponse} e
- * @protected
- */
-plugin.geopackage.RequestHandler.prototype.onMessage = function(e) {
-  var msg = /** @type {GeoPackageWorkerResponse} */ (e instanceof window.Event ? e.data : e);
-
-  if (msg.message.id === this.lastId && msg.message.tableName === this.lastTableName) {
-    var worker = plugin.geopackage.getWorker();
-
-    if (msg.type === plugin.geopackage.MsgType.SUCCESS) {
-      if (msg.data === 0) {
-        // finished
-        worker.removeEventListener(goog.events.EventType.MESSAGE, this.workerHandler_);
-        this.dispatchEvent(goog.net.EventType.SUCCESS);
-      } else if (msg.data) {
-        if ('geometry' in msg.data['properties']) {
-          // this will really screw up the resulting feature
-          delete msg.data['properties']['geometry'];
+          this.features.push(msg.data);
         }
-
-        if (!this.features) {
-          this.features = [];
-        }
-
-        this.features.push(msg.data);
+      } else {
+        worker.removeEventListener(GoogEventType.MESSAGE, this.workerHandler_);
+        this.errors.push(String(msg.reason));
+        this.statusCode = 500;
+        this.dispatchEvent(NetEventType.ERROR);
       }
-    } else {
-      worker.removeEventListener(goog.events.EventType.MESSAGE, this.workerHandler_);
-      this.errors.push(String(msg.reason));
-      this.statusCode = 500;
-      this.dispatchEvent(goog.net.EventType.ERROR);
     }
   }
-};
+}
+
+
+exports = RequestHandler;

--- a/src/plugin/geopackage/geopackagetile.js
+++ b/src/plugin/geopackage/geopackagetile.js
@@ -1,32 +1,35 @@
-goog.provide('plugin.geopackage.Tile');
+goog.module('plugin.geopackage.Tile');
 
-goog.require('os.tile.ColorableTile');
+const ColorableTile = goog.require('os.tile.ColorableTile');
 
 
 /**
  * Implementation of a tile that is colorable.
- * @param {ol.TileCoord} tileCoord Tile coordinate.
- * @param {ol.TileState} state State.
- * @param {string} src Image source URI.
- * @param {?string} crossOrigin Cross origin.
- * @param {ol.TileLoadFunctionType} tileLoadFunction Tile load function.
- * @extends {os.tile.ColorableTile}
- * @constructor
  */
-plugin.geopackage.Tile = function(tileCoord, state, src, crossOrigin, tileLoadFunction) {
-  plugin.geopackage.Tile.base(this, 'constructor', tileCoord, state, src, crossOrigin, tileLoadFunction);
-};
-goog.inherits(plugin.geopackage.Tile, os.tile.ColorableTile);
-
-/**
- * @inheritDoc
- */
-plugin.geopackage.Tile.prototype.disposeInternal = function() {
-  var src = this.getImage().src;
-  if (src) {
-    URL.revokeObjectURL(src);
+class Tile extends ColorableTile {
+  /**
+   * Constructor.
+   * @param {ol.TileCoord} tileCoord Tile coordinate.
+   * @param {ol.TileState} state State.
+   * @param {string} src Image source URI.
+   * @param {?string} crossOrigin Cross origin.
+   * @param {ol.TileLoadFunctionType} tileLoadFunction Tile load function.
+   */
+  constructor(tileCoord, state, src, crossOrigin, tileLoadFunction) {
+    super(tileCoord, state, src, crossOrigin, tileLoadFunction);
   }
 
-  plugin.geopackage.Tile.base(this, 'disposeInternal');
-};
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    const src = this.getImage().src;
+    if (src) {
+      URL.revokeObjectURL(src);
+    }
 
+    super.disposeInternal();
+  }
+}
+
+exports = Tile;

--- a/src/plugin/geopackage/geopackagetilelayerconfig.js
+++ b/src/plugin/geopackage/geopackagetilelayerconfig.js
@@ -1,138 +1,147 @@
-goog.provide('plugin.geopackage.TileLayerConfig');
+goog.module('plugin.geopackage.TileLayerConfig');
 
-goog.require('goog.log');
-goog.require('ol.ImageTile');
-goog.require('ol.TileState');
-goog.require('ol.source.TileImage');
-goog.require('ol.tilegrid.TileGrid');
-goog.require('os.layer.config.AbstractTileLayerConfig');
-goog.require('plugin.geopackage.Tile');
+const GoogEventType = goog.require('goog.events.EventType');
+const log = goog.require('goog.log');
+const ImageTile = goog.require('ol.ImageTile');
+const TileState = goog.require('ol.TileState');
+const TileImage = goog.require('ol.source.TileImage');
+const TileGrid = goog.require('ol.tilegrid.TileGrid');
+const AbstractTileLayerConfig = goog.require('os.layer.config.AbstractTileLayerConfig');
+const {MsgType, getWorker} = goog.require('plugin.geopackage');
+const Tile = goog.require('plugin.geopackage.Tile');
+
+
+/**
+ * The logger.
+ * @type {log.Logger}
+ */
+const LOGGER = log.getLogger('plugin.geopackage.TileLayerConfig');
+
+
+/**
+ * @type {boolean}
+ */
+let tileListenerSet = false;
+
+
+/**
+ * @type {!Object<string, !ImageTile>}
+ */
+const tiles = {};
 
 
 /**
  * Creates a tile layer from a GeoPackage.
- *
- * @extends {os.layer.config.AbstractTileLayerConfig}
- * @constructor
  */
-plugin.geopackage.TileLayerConfig = function() {
-  plugin.geopackage.TileLayerConfig.base(this, 'constructor');
-  this.tileClass = plugin.geopackage.Tile;
-};
-goog.inherits(plugin.geopackage.TileLayerConfig, os.layer.config.AbstractTileLayerConfig);
+class TileLayerConfig extends AbstractTileLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+    this.tileClass = Tile;
+  }
 
+  /**
+   * @inheritDoc
+   */
+  getSource(options) {
+    const parts = options['id'].split(os.ui.data.BaseProvider.ID_DELIMITER);
 
-/**
- * @inheritDoc
- */
-plugin.geopackage.TileLayerConfig.prototype.getSource = function(options) {
-  var parts = options['id'].split(os.ui.data.BaseProvider.ID_DELIMITER);
+    const source = new TileImage(/** @type {olx.source.TileImageOptions} */ ({
+      'projection': this.projection,
+      'tileLoadFunction': getTileLoadFunction(parts[0]),
+      'tileUrlFunction': getTileUrlFunction(parts[1]),
+      'tileGrid': new TileGrid(/** @type {olx.tilegrid.TileGridOptions} */ ({
+        'extent': options.extent,
+        'minZoom': Math.max(0, Math.round(options['minZoom'])),
+        'resolutions': options['resolutions'],
+        'tileSizes': options['tileSizes']
+      })),
+      'wrapX': this.projection.isGlobal()
+    }));
 
-  var source = new ol.source.TileImage(/** @type {olx.source.TileImageOptions} */ ({
-    'projection': this.projection,
-    'tileLoadFunction': plugin.geopackage.getTileLoadFunction_(parts[0]),
-    'tileUrlFunction': plugin.geopackage.getTileUrlFunction_(parts[1]),
-    'tileGrid': new ol.tilegrid.TileGrid(/** @type {olx.tilegrid.TileGridOptions} */ ({
-      'extent': options.extent,
-      'minZoom': Math.max(0, Math.round(options['minZoom'])),
-      'resolutions': options['resolutions'],
-      'tileSizes': options['tileSizes']
-    })),
-    'wrapX': this.projection.isGlobal()
-  }));
-
-  plugin.geopackage.addTileListener_();
-  return source;
-};
+    addTileListener();
+    return source;
+  }
+}
 
 
 /**
  * @param {string} providerId
  * @return {!ol.TileLoadFunctionType}
- * @private
  */
-plugin.geopackage.getTileLoadFunction_ = function(providerId) {
-  return (
-    /**
-     * @param {ol.Tile} tile The image tile
-     * @param {string} layerName The layer name
-     */
-    function(tile, layerName) {
-      var imageTile = /** @type {ol.ImageTile} */ (tile);
-      var prevSrc = imageTile.getImage().src;
-      if (prevSrc) {
-        // recycle it
-        URL.revokeObjectURL(prevSrc);
-      }
+const getTileLoadFunction = (providerId) => (
+  /**
+   * @param {ol.Tile} tile The image tile
+   * @param {string} layerName The layer name
+   */
+  (tile, layerName) => {
+    const imageTile = /** @type {ImageTile} */ (tile);
+    const prevSrc = imageTile.getImage().src;
+    if (prevSrc) {
+      // recycle it
+      URL.revokeObjectURL(prevSrc);
+    }
 
-      if (layerName) {
-        var msg = /** @type {GeoPackageWorkerMessage} */ ({
-          id: providerId,
-          type: plugin.geopackage.MsgType.GET_TILE,
-          tableName: layerName,
-          tileCoord: imageTile.getTileCoord()
-        });
+    if (layerName) {
+      const msg = /** @type {GeoPackageWorkerMessage} */ ({
+        id: providerId,
+        type: MsgType.GET_TILE,
+        tableName: layerName,
+        tileCoord: imageTile.getTileCoord()
+      });
 
-        var key = msg.id + '#' + msg.type + '#' + msg.tableName + '#' + msg.tileCoord.join(',');
-        plugin.geopackage.tiles_[key] = imageTile;
-        plugin.geopackage.getWorker().postMessage(msg);
-      }
-    });
-};
+      const key = msg.id + '#' + msg.type + '#' + msg.tableName + '#' + msg.tileCoord.join(',');
+      tiles[key] = imageTile;
+      getWorker().postMessage(msg);
+    }
+  }
+);
 
 
 /**
- * @type {boolean}
- * @private
  */
-plugin.geopackage.tileListenerSet_ = false;
-
-
-/**
- * @private
- */
-plugin.geopackage.addTileListener_ = function() {
-  if (!plugin.geopackage.tileListenerSet_) {
-    plugin.geopackage.getWorker().addEventListener(goog.events.EventType.MESSAGE, plugin.geopackage.tileListener_);
-    plugin.geopackage.tileListenerSet_ = true;
+const addTileListener = () => {
+  if (!tileListenerSet) {
+    getWorker().addEventListener(GoogEventType.MESSAGE, tileListener);
+    tileListenerSet = true;
   }
 };
 
 
 /**
- * @type {!Object<string, !ol.ImageTile>}
- */
-plugin.geopackage.tiles_ = {};
-
-
-/**
  * @param {Event|GeoPackageWorkerResponse} evt
- * @private
  * @suppress {accessControls}
  */
-plugin.geopackage.tileListener_ = function(evt) {
-  var msg = /** @type {GeoPackageWorkerResponse} */ (evt instanceof Event ? evt.data : evt);
+const tileListener = (evt) => {
+  const msg = /** @type {GeoPackageWorkerResponse} */ (evt instanceof Event ? evt.data : evt);
 
-  if (msg.message.type === plugin.geopackage.MsgType.GET_TILE) {
-    var key = msg.message.id + '#' + msg.message.type + '#' + msg.message.tableName + '#' +
-        msg.message.tileCoord.join(',');
-    var imageTile = plugin.geopackage.tiles_[key];
+  if (msg.message.type === MsgType.GET_TILE) {
+    const key = [
+      msg.message.id,
+      msg.message.type,
+      msg.message.tableName,
+      msg.message.tileCoord.join(',')
+    ].join('#');
+
+    const imageTile = tiles[key];
 
     if (imageTile) {
-      delete plugin.geopackage.tiles_[key];
+      delete tiles[key];
 
-      if (msg.type === plugin.geopackage.MsgType.SUCCESS) {
+      if (msg.type === MsgType.SUCCESS) {
         if (msg.data) {
-          var url = null;
+          let url = null;
 
           if (typeof msg.data === 'string') {
             // Web Worker path
             url = msg.data;
-          } else if (goog.isArray(msg.data)) {
+          } else if (Array.isArray(msg.data)) {
             // node process path
-            var i32arr = Int32Array.from(/** @type {!Array<!number>} */ (msg.data));
-            var i8arr = new Uint8Array(i32arr);
-            var blob = new Blob([i8arr]);
+            const i32arr = Int32Array.from(/** @type {!Array<!number>} */ (msg.data));
+            const i8arr = new Uint8Array(i32arr);
+            const blob = new Blob([i8arr]);
             url = URL.createObjectURL(blob);
           }
 
@@ -140,16 +149,16 @@ plugin.geopackage.tileListener_ = function(evt) {
             imageTile.getImage().src = url;
           }
         } else {
-          // Tile is emtpy, so display a blank image. Note that ol.TileState.EMPTY is NOT WHAT WE WANT.
+          // Tile is emtpy, so display a blank image. Note that TileState.EMPTY is NOT WHAT WE WANT.
           // Empty causes OpenLayers to keep displaying the parent tile for coverage. We want a blank
           // tile.
-          imageTile.image_ = ol.ImageTile.getBlankImage();
-          imageTile.state = ol.TileState.LOADED;
+          imageTile.image_ = ImageTile.getBlankImage();
+          imageTile.state = TileState.LOADED;
           imageTile.changed();
         }
       } else {
         imageTile.handleImageError_();
-        goog.log.error(plugin.geopackage.LOGGER, 'Error querying tile from GeoPackage:' + msg.reason);
+        log.error(LOGGER, 'Error querying tile from GeoPackage:' + msg.reason);
       }
     }
   }
@@ -161,15 +170,14 @@ plugin.geopackage.tileListener_ = function(evt) {
  * @return {ol.TileUrlFunctionType}
  * @private
  */
-plugin.geopackage.getTileUrlFunction_ = function(layerName) {
-  return (
-    /**
-     * @param {ol.TileCoord} tileCoord The tile coordinate
-     * @param {number} pixelRatio The tile pixel ratio
-     * @param {ol.proj.Projection} projection The projection
-     * @return {string|undefined} Tile URL
-     */
-    function(tileCoord, pixelRatio, projection) {
-      return layerName;
-    });
-};
+const getTileUrlFunction = (layerName) => (
+  /**
+   * @param {ol.TileCoord} tileCoord The tile coordinate
+   * @param {number} pixelRatio The tile pixel ratio
+   * @param {ol.proj.Projection} projection The projection
+   * @return {string|undefined} Tile URL
+   */
+  (tileCoord, pixelRatio, projection) => layerName
+);
+
+exports = TileLayerConfig;

--- a/src/plugin/geopackage/geopackagetilelayerconfig.js
+++ b/src/plugin/geopackage/geopackagetilelayerconfig.js
@@ -45,6 +45,19 @@ class TileLayerConfig extends AbstractTileLayerConfig {
   /**
    * @inheritDoc
    */
+  initializeConfig(options) {
+    // If a zoomOffset isn't already defined, set it to 0 to avoid auto detection. Geopackages should not need to set
+    // this to anything other than 0.
+    if (options['zoomOffset'] == null) {
+      options['zoomOffset'] = 0;
+    }
+
+    super.initializeConfig(options);
+  }
+
+  /**
+   * @inheritDoc
+   */
   getSource(options) {
     const parts = options['id'].split(os.ui.data.BaseProvider.ID_DELIMITER);
 

--- a/src/plugin/geopackage/geopackagevectorlayerconfig.js
+++ b/src/plugin/geopackage/geopackagevectorlayerconfig.js
@@ -1,82 +1,93 @@
-goog.provide('plugin.geopackage.VectorLayerConfig');
+goog.module('plugin.geopackage.VectorLayerConfig');
 
-goog.require('os.im.mapping.TimeType');
-goog.require('os.im.mapping.time.DateTimeMapping');
-goog.require('os.ogc.wfs.FeatureType');
-goog.require('plugin.file.geojson.GeoJSONLayerConfig');
-goog.require('plugin.ogc.wfs.WFSLayerConfig');
+const AltMapping = goog.require('os.im.mapping.AltMapping');
+const RadiusMapping = goog.require('os.im.mapping.RadiusMapping');
+const SemiMajorMapping = goog.require('os.im.mapping.SemiMajorMapping');
+const SemiMinorMapping = goog.require('os.im.mapping.SemiMinorMapping');
+const TimeFormat = goog.require('os.im.mapping.TimeFormat');
+const TimeType = goog.require('os.im.mapping.TimeType');
+const DateTimeMapping = goog.require('os.im.mapping.time.DateTimeMapping');
+const FeatureType = goog.require('os.ogc.wfs.FeatureType');
+const GeoJSONLayerConfig = goog.require('plugin.file.geojson.GeoJSONLayerConfig');
 
 
-/**
- * @extends {plugin.file.geojson.GeoJSONLayerConfig}
- * @constructor
- */
-plugin.geopackage.VectorLayerConfig = function() {
-  plugin.geopackage.VectorLayerConfig.base(this, 'constructor');
-};
-goog.inherits(plugin.geopackage.VectorLayerConfig, plugin.file.geojson.GeoJSONLayerConfig);
+const FeatureTypeColumn = goog.requireType('os.ogc.FeatureTypeColumn');
 
 
 /**
- * @inheritDoc
  */
-plugin.geopackage.VectorLayerConfig.prototype.getLayer = function(source, options) {
-  var featureType = new os.ogc.wfs.FeatureType(
-      /** @type {string} */ (options['id']),
-      /** @type {Array<!os.ogc.FeatureTypeColumn>} */ (options['dbColumns']));
+class VectorLayerConfig extends GeoJSONLayerConfig {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    super();
+  }
 
-  var layer = plugin.geopackage.VectorLayerConfig.base(this, 'getLayer', source, options);
+  /**
+   * @inheritDoc
+   */
+  getLayer(source, options) {
+    const layer = super.getLayer(source, options);
 
-  this.fixFeatureTypeColumns(layer, options, featureType);
-  this.addMappings(layer, options, featureType);
+    const featureType = new FeatureType(/** @type {string} */ (options['id']),
+        /** @type {Array<!FeatureTypeColumn>} */ (options['dbColumns']));
+    this.fixFeatureTypeColumns(layer, options, featureType);
+    this.addMappings(layer, options, featureType);
 
-  return layer;
-};
+    return layer;
+  }
 
+  /**
+   * @param {os.layer.Vector} layer
+   * @param {Object<string, *>} options
+   * @param {os.ogc.IFeatureType} featureType
+   */
+  addMappings(layer, options, featureType) {
+    const animate = options['animate'] != null ? options['animate'] : false;
+    const source = /** @type {os.source.Request} */ (layer.getSource());
+    const importer = /** @type {os.im.Importer} */ (source.getImporter());
 
-/**
- * @param {os.layer.Vector} layer
- * @param {Object<string, *>} options
- * @param {os.ogc.IFeatureType} featureType
- */
-plugin.geopackage.VectorLayerConfig.prototype.addMappings = function(layer, options, featureType) {
-  var animate = options['animate'] != null ? options['animate'] : false;
-  var source = /** @type {os.source.Request} */ (layer.getSource());
-  var importer = /** @type {os.im.Importer} */ (source.getImporter());
+    const execMappings = [];
+    const startField = featureType.getStartDateColumnName();
+    const endField = featureType.getEndDateColumnName();
 
-  var execMappings = [];
-  var startField = featureType.getStartDateColumnName();
-  var endField = featureType.getEndDateColumnName();
+    if (animate && startField) {
+      if (startField != endField) {
+        // add a start/end datetime mapping
+        // this mapping does not remove the original fields since it's mapping two fields to one, and the original
+        // fields may be wanted when exporting data
+        const startMapping = new DateTimeMapping(TimeType.START);
+        startMapping.field = startField;
+        startMapping.setFormat(TimeFormat.ISO);
+        execMappings.push(startMapping);
 
-  if (animate && startField) {
-    if (startField != endField) {
-      // add a start/end datetime mapping
-      // this mapping does not remove the original fields since it's mapping two fields to one, and the original
-      // fields may be wanted when exporting data
-      var mapping = new os.im.mapping.time.DateTimeMapping(os.im.mapping.TimeType.START);
-      mapping.field = startField;
-      mapping.setFormat(os.im.mapping.TimeFormat.ISO);
-      execMappings.push(mapping);
-
-      mapping = new os.im.mapping.time.DateTimeMapping(os.im.mapping.TimeType.END);
-      mapping.field = endField;
-      mapping.setFormat(os.im.mapping.TimeFormat.ISO);
-      execMappings.push(mapping);
-    } else {
-      // add a datetime mapping
-      // this mapping removes the original field since we're replacing the original with our own
-      mapping = new os.im.mapping.time.DateTimeMapping(os.im.mapping.TimeType.INSTANT);
-      mapping.field = startField;
-      mapping.setFormat(os.im.mapping.TimeFormat.ISO);
-      execMappings.push(mapping);
+        const endMapping = new DateTimeMapping(TimeType.END);
+        endMapping.field = endField;
+        endMapping.setFormat(TimeFormat.ISO);
+        execMappings.push(endMapping);
+      } else {
+        // add a datetime mapping
+        // this mapping removes the original field since we're replacing the original with our own
+        const timeMapping = new DateTimeMapping(TimeType.INSTANT);
+        timeMapping.field = startField;
+        timeMapping.setFormat(TimeFormat.ISO);
+        execMappings.push(timeMapping);
+      }
     }
-  }
 
-  if (execMappings && execMappings.length > 0) {
-    importer.setExecMappings(execMappings);
-  }
+    if (execMappings && execMappings.length > 0) {
+      importer.setExecMappings(execMappings);
+    }
 
-  // tell the importer we want to run a different set of autodetection mappers
-  importer.selectAutoMappings([os.im.mapping.AltMapping.ID, os.im.mapping.RadiusMapping.ID,
-    os.im.mapping.SemiMajorMapping.ID, os.im.mapping.SemiMinorMapping.ID]);
-};
+    // tell the importer we want to run a different set of autodetection mappers
+    importer.selectAutoMappings([
+      AltMapping.ID,
+      RadiusMapping.ID,
+      SemiMajorMapping.ID,
+      SemiMinorMapping.ID
+    ]);
+  }
+}
+
+exports = VectorLayerConfig;

--- a/src/plugin/geopackage/mime.js
+++ b/src/plugin/geopackage/mime.js
@@ -1,34 +1,34 @@
-goog.provide('plugin.geopackage.mime');
+goog.module('plugin.geopackage.mime');
 
-goog.require('goog.Promise');
-goog.require('os.file.mime');
+const Promise = goog.require('goog.Promise');
+const mime = goog.require('os.file.mime');
 
 
 /**
  * @type {string}
  * @const
  */
-plugin.geopackage.mime.TYPE = 'application/vnd.opengeospatial.geopackage+sqlite3';
+exports.TYPE = 'application/vnd.opengeospatial.geopackage+sqlite3';
 
 
 /**
  * @param {ArrayBuffer} buffer
  * @param {os.file.File} file
  * @param {*=} opt_context
- * @return {!goog.Promise<*|undefined>}
+ * @return {!Promise<*|undefined>}
  */
-plugin.geopackage.mime.detect = function(buffer, file, opt_context) {
-  var retVal = false;
+exports.detect = (buffer, file, opt_context) => {
+  let retVal = false;
 
-  var str = 'SQLite format 3';
+  const str = 'SQLite format 3';
   if (file && file.getFileName() && /\.gpkg$/.test(file.getFileName()) &&
     buffer && buffer.byteLength > str.length && String.fromCharCode(
       ...new Uint8Array(buffer).slice(0, str.length)) === str) {
     retVal = true;
   }
 
-  return /** @type {!goog.Promise<*|undefined>} */ (goog.Promise.resolve(retVal));
+  return /** @type {!Promise<*|undefined>} */ (Promise.resolve(retVal));
 };
 
 
-os.file.mime.register(plugin.geopackage.mime.TYPE, plugin.geopackage.mime.detect);
+mime.register(exports.TYPE, exports.detect);

--- a/test/plugin/geopackage/geopackageplugin.test.js
+++ b/test/plugin/geopackage/geopackageplugin.test.js
@@ -3,13 +3,15 @@ goog.require('os.mock');
 goog.require('plugin.geopackage.GeoPackagePlugin');
 
 describe('plugin.geopackage.GeoPackagePlugin', function() {
+  const GeoPackagePlugin = goog.module.get('plugin.geopackage.GeoPackagePlugin');
+
   it('should have the proper ID', function() {
-    expect(new plugin.geopackage.GeoPackagePlugin().id).toBe('geopackage');
+    expect(new GeoPackagePlugin().id).toBe('geopackage');
   });
 
   it('should not throw an error', function() {
-    var fn = function() {
-      var p = new plugin.geopackage.GeoPackagePlugin();
+    const fn = function() {
+      const p = new GeoPackagePlugin();
       p.init();
     };
 

--- a/test/plugin/geopackage/geopackageprovider.test.js
+++ b/test/plugin/geopackage/geopackageprovider.test.js
@@ -2,13 +2,14 @@ goog.require('plugin.geopackage.GeoPackageProvider');
 
 
 describe('plugin.geopackage.GeoPackageProvider', function() {
-  plugin['geopackage']['ROOT'] = 'base/';
-  var baseUrl = '/base/test/resources/geopackage/';
+  const GeoPackageProvider = goog.module.get('plugin.geopackage.GeoPackageProvider');
+
+  const baseUrl = '/base/test/resources/geopackage/';
 
   it('should configure properly', function() {
-    var p = new plugin.geopackage.GeoPackageProvider();
+    const p = new GeoPackageProvider();
 
-    var conf = {
+    const conf = {
       type: 'geopackage',
       label: 'Test Label',
       url: '/path/to/something.gpkg'
@@ -21,11 +22,11 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
   });
 
   it('should parse geopackages properly', function() {
-    var p = new plugin.geopackage.GeoPackageProvider();
+    const p = new GeoPackageProvider();
     p.setUrl(baseUrl + 'gdal_sample_v1.2_no_extensions.gpkg');
 
-    var count = 0;
-    var listener = function(e) {
+    let count = 0;
+    const listener = function(e) {
       count++;
     };
 
@@ -40,10 +41,10 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
     }, 'GeoPackage to load', 5000);
 
     runs(function() {
-      var children = p.getChildren();
-      var prefix = p.getId() + os.ui.data.BaseProvider.ID_DELIMITER;
+      const children = p.getChildren();
+      const prefix = p.getId() + os.ui.data.BaseProvider.ID_DELIMITER;
 
-      var expected = [{
+      const expected = [{
         id: prefix + 'byte_jpeg',
         title: 'byte_jpeg',
         layerType: os.layer.LayerType.TILES,
@@ -147,7 +148,7 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
 
       expect(children.length).toBe(expected.length);
       for (var i = 0, n = children.length; i < n; i++) {
-        var config = children[i].getDescriptor().getBaseConfig();
+        const config = children[i].getDescriptor().getBaseConfig();
 
         expect(config.provider).toBe(p.getLabel());
         expect(config.delayUpdateActive).toBe(true);
@@ -160,8 +161,8 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
   });
 
   it('should log errors of all types', function() {
-    var p = new plugin.geopackage.GeoPackageProvider();
-    var fns = [
+    const p = new GeoPackageProvider();
+    const fns = [
       function() {
         p.logError(undefined);
       }, function() {
@@ -185,7 +186,7 @@ describe('plugin.geopackage.GeoPackageProvider', function() {
   });
 
   it('should handle request errors', function() {
-    var p = new plugin.geopackage.GeoPackageProvider();
+    const p = new GeoPackageProvider();
     p.setUrl(baseUrl + 'doesnotexist.gpkg');
 
     runs(function() {


### PR DESCRIPTION
Refactored everything in `src/plugin` to use `goog.module` and removed all `declareLegacyNamespace` calls. I did a pass over the code to add explicit requires, convert `var` to `const/let`, and some other minor cleanup.

I came across a bug where Geopackage providers would not be restored properly from settings if you had multiple loaded. `GeoPackageProvider` had a `getInstance` call from `goog.addSingletonGetter`, which causes the data manager to create the provider using that method. When subsequent providers are created, they reuse the first instance and make changes to it. It didn't seem like the provider should have a singleton, so I removed `getInstance` from it.

Demo: https://brash-lock.surge.sh/

Example GPKG files can be found here:

- https://www.geopackage.org/data.html
- https://www.geopackage.org/guide/implementation_guide.html