### PR TITLE
fix(electron): fix native build of canvas by electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "index": "index.js",
     "electron": {
       "packages": [
-        "@ngageoint/geopackage"
+        "@ngageoint/geopackage",
+        "nan"
       ],
       "preload": [
         "./src/electron/preload.js"
@@ -107,6 +108,7 @@
   },
   "dependencies": {
     "@ngageoint/geopackage": "^2.0.0",
+    "nan": "2.14.0",
     "opensphere": "0.0.0-development"
   },
   "husky": {


### PR DESCRIPTION
This will add a pinned `nan@2.14.0` dependency to the generated `opensphere-electron/app/package.json`, which fixes an issue building the native `canvas` dependency on Windows.