### PR TITLE
fix(goog): fix logger typing

### DIFF
--- a/src/plugin/geopackage/geopackage.js
+++ b/src/plugin/geopackage/geopackage.js
@@ -2,6 +2,8 @@ goog.module('plugin.geopackage');
 
 const log = goog.require('goog.log');
 
+const Logger = goog.requireType('goog.log.Logger');
+
 
 /**
  * @define {string}
@@ -23,7 +25,7 @@ exports.ID = 'geopackage';
 /**
  * The logger.
  * @const
- * @type {goog.debug.Logger}
+ * @type {Logger}
  */
 const LOGGER = log.getLogger('plugin.geopackage');
 


### PR DESCRIPTION
`goog.log.getLogger` returns a `goog.log.Logger`, not `goog.debug.Logger`. This will be reported as an error if the Closure library is updated.