### PR TITLE
fix(sqlite): downgrade better-sqlite3 to 7.1.2 to fix glibc incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "dependencies": {
     "@ngageoint/geopackage": "^4.0.0-beta.29",
-    "better-sqlite3": "7.1.4",
+    "better-sqlite3": "7.1.2",
     "nan": "2.14.0",
     "opensphere": "0.0.0-development"
   },


### PR DESCRIPTION
`better-sqlite3@7.1.4` was built on Ubuntu 20.04, which uses glibc 2.29. The prebuild script for the package requires that version of glibc, which is not available on lesser versions of Ubuntu, RHEL 7, etc. This will be resolved once JoshuaWise/better-sqlite3/pull/631 is merged/released, but for now the workaround is to roll back to 7.1.2.