### PR TITLE
fix(tiles): use tile scaling to support gpkg tiles at all zooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "semantic-release": "^15.13.32"
   },
   "dependencies": {
-    "@ngageoint/geopackage": "^4.0.0-beta.29",
+    "@ngageoint/geopackage": "^4.0.0-beta.33",
     "better-sqlite3": "7.1.2",
     "nan": "2.14.0",
     "opensphere": "0.0.0-development"

--- a/src/plugin/geopackage/geopackageprovider.js
+++ b/src/plugin/geopackage/geopackageprovider.js
@@ -5,14 +5,12 @@ const log = goog.require('goog.log');
 const NetEventType = goog.require('goog.net.EventType');
 const ResponseType = goog.require('goog.net.XhrIo.ResponseType');
 const {makeSafe, intAwareCompare} = goog.require('goog.string');
-const olProj = goog.require('ol.proj');
 
 const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
 const AlertManager = goog.require('os.alert.AlertManager');
 const ConfigDescriptor = goog.require('os.data.ConfigDescriptor');
 const {isFileSystem} = goog.require('os.file');
 const LayerType = goog.require('os.layer.LayerType');
-const osMap = goog.require('os.map');
 const Request = goog.require('os.net.Request');
 const Icons = goog.require('os.ui.Icons');
 const BaseProvider = goog.require('os.ui.data.BaseProvider');
@@ -20,6 +18,7 @@ const DescriptorNode = goog.require('os.ui.data.DescriptorNode');
 const {directiveTag} = goog.require('os.ui.data.LayerCheckboxUI');
 const AbstractLoadingServer = goog.require('os.ui.server.AbstractLoadingServer');
 const {getWorker, isElectron, MsgType, ID} = goog.require('plugin.geopackage');
+const {MIN_ZOOM, MAX_ZOOM} = goog.require('os.map');
 
 const GoogEvent = goog.requireType('goog.events.Event');
 
@@ -249,19 +248,9 @@ class GeoPackageProvider extends AbstractLoadingServer {
       config['layerType'] = LayerType.TILES;
       config['icons'] = Icons.TILES;
 
-      const gpkgProjection = /** @type {string} */ (config['projection']);
-      const projection = gpkgProjection ? olProj.get(gpkgProjection) : undefined;
-
-      const resolutions = /** @type {Array<number>} */ (config['resolutions']);
-      if (projection && resolutions && resolutions.length) {
-        config['minZoom'] = Math.floor(osMap.resolutionToZoom(resolutions[0], projection));
-        config['maxZoom'] = Math.ceil(osMap.resolutionToZoom(resolutions[resolutions.length - 1], projection)) + 1;
-      } else {
-        const minZoom = config['minZoom'] != null ? config['minZoom'] : 0;
-        const maxZoom = config['maxZoom'] != null ? config['maxZoom'] : 0;
-        config['minZoom'] = Math.max(minZoom, 0);
-        config['maxZoom'] = Math.min(maxZoom, 42);
-      }
+      // we want the tiles to support the full zoom range, so set them regardless of what the file has configured
+      config['minZoom'] = MIN_ZOOM;
+      config['maxZoom'] = MAX_ZOOM;
     } else if (config['type'] === ID + '-vector') {
       const animate = config['dbColumns'].some((col) => col['type'] === 'datetime');
 

--- a/src/plugin/geopackage/geopackagetilelayerconfig.js
+++ b/src/plugin/geopackage/geopackagetilelayerconfig.js
@@ -83,7 +83,7 @@ class TileLayerConfig extends AbstractTileLayerConfig {
       'tileLoadFunction': getTileLoadFunction(parts[0], gpkgTileGrid, layerTileGrid),
       'tileUrlFunction': getTileUrlFunction(parts[1]),
       'tileGrid': layerTileGrid,
-      'wrapX': this.projection.isGlobal()
+      'wrapX': false // TODO: fix wrapping tiles crashing and displaying incorrectly outside the world extent
     }));
 
     source.setExtent(options.extent);

--- a/src/worker/gpkg.worker.js
+++ b/src/worker/gpkg.worker.js
@@ -292,7 +292,6 @@ var listDescriptors = function(msg) {
 
         if (info) {
           var tileMatrices = tileDao.zoomLevelToTileMatrix;
-
           var config = {
             type: 'geopackage-tile',
             title: info.tableName,
@@ -303,13 +302,14 @@ var listDescriptors = function(msg) {
             tileSizes: fixSizes(tileMatrices.map(tileMatrixToTileSize))
           };
 
-          // create and store a TileScaling for each tile layer that allows requesting tiles at +-25 zoom levels
-          // in order to guarantee that GPKG tile layers are visible at all zoom levels
+          // Create and store a TileScaling for each tile layer that allows requesting tiles at +4 to -25 zoom levels.
+          // This allows tile to show at all zoom levels above where the file defines, but only up to +4 zoom levels
+          // higher. Tiles tend to become too blurred once upscaled much more than that.
           tileScaling = new GeoPackage.TileScaling();
           /* eslint-disable google-camelcase/google-camelcase */
           tileScaling.scaling_type = GeoPackage.TileScalingType.IN_OUT;
           tileScaling.zoom_in = 25;
-          tileScaling.zoom_out = 25;
+          tileScaling.zoom_out = 4;
           /* eslint-enable google-camelcase/google-camelcase */
 
           const tileScalingExtension = gpkg.getTileScalingExtension(tableName);


### PR DESCRIPTION
Upgrades the geopackage dependency to beta.33 to fix a bug with multiple tile tables in a single gpkg file. Also works around an issue in 2D mode where requesting tiles outside of the default world extent would either result in distorted tiles or flat out crashing the browser in some cases.