### PR TITLE
fix(columns): create source columns with the same name used by features

### DIFF
--- a/src/worker/gpkg.worker.js
+++ b/src/worker/gpkg.worker.js
@@ -350,7 +350,11 @@ var listDescriptors = function(msg) {
             var dataType = GeoPackage.GeoPackageDataType[col.dataType] || '';
             return /** @type {os.ogc.FeatureTypeColumn} */ ({
               type: dataType.toLowerCase(),
-              name: col.name
+              // iterateGeoJSONFeatures uses the displayName for the feature properties. if the gpkg has a
+              // gpkg_data_columns table, col.displayName may differ from col.name. if that table doesn't exist, these
+              // fields should be the same. the fallback to col.name is a sanity check, but shouldn't be needed in
+              // practice.
+              name: col.displayName || col.name
             });
           });
 


### PR DESCRIPTION
If a GPKG has a `gpkg_data_columns` table, the columns returned by `getInfoForTable` may have differing `name` and `displayName` fields. We were using the `name` field, but GeoJSON returned by `iterateGeoJSONFeatures` uses the `displayName` field for feature properties. This was breaking things like feature info, labels, etc that map source columns to feature properties.