### PR TITLE
feat(deps): upgrade better-sqlite to support electron 13 prebuilt binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,8 @@
     "semantic-release": "^15.13.32"
   },
   "dependencies": {
-    "@ngageoint/geopackage": "^4.0.0-beta.33",
-    "better-sqlite3": "7.1.2",
+    "@ngageoint/geopackage": "^4.0.0-beta.34",
+    "better-sqlite3": "7.4.1",
     "nan": "2.14.0",
     "opensphere": "0.0.0-development"
   },


### PR DESCRIPTION
`better-sqlite3@7.4.1` includes prebuilt binaries for Electron 13, which allows the build to simply download them instead of building them locally. The updated release of `@ngageoint/geopackage` also uses this version.