### PR TITLE
refactor(file): use getter to check if local file urls are enabled

### DIFF
--- a/src/plugin/geopackage/geopackageimportui.js
+++ b/src/plugin/geopackage/geopackageimportui.js
@@ -9,7 +9,7 @@ const GeoPackageProvider = goog.require('plugin.geopackage.GeoPackageProvider');
 const OSFile = goog.requireType('os.file.File');
 const geopackage = goog.require('plugin.geopackage');
 const windows = goog.require('os.ui.menu.windows');
-const {isLocal, FILE_URL_ENABLED} = goog.require('os.file');
+const {isLocal, isFileUrlEnabled} = goog.require('os.file');
 
 const DataProviderEvent = goog.requireType('os.data.DataProviderEvent');
 
@@ -22,7 +22,7 @@ class GeoPackageImportUI extends AbstractImportUI {
    */
   constructor() {
     super();
-    this.requiresStorage = !FILE_URL_ENABLED;
+    this.requiresStorage = !isFileUrlEnabled();
 
     /**
      * @type {OSFile}

--- a/src/plugin/geopackage/geopackageimportui.js
+++ b/src/plugin/geopackage/geopackageimportui.js
@@ -3,6 +3,7 @@ goog.module('plugin.geopackage.GeoPackageImportUI');
 const AbstractImportUI = goog.require('os.ui.im.AbstractImportUI');
 const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
 const AlertManager = goog.require('os.alert.AlertManager');
+const DataManager = goog.require('os.data.DataManager');
 const DataProviderEventType = goog.require('os.data.DataProviderEventType');
 const FileStorage = goog.require('os.file.FileStorage');
 const GeoPackageProvider = goog.require('plugin.geopackage.GeoPackageProvider');
@@ -40,7 +41,7 @@ class GeoPackageImportUI extends AbstractImportUI {
       const url = file.getUrl();
 
       // see if there are any other geopackage providers for the same file
-      const list = os.dataManager.getProviderRoot().getChildren()
+      const list = DataManager.getInstance().getProviderRoot().getChildren()
           .filter((provider) => provider instanceof GeoPackageProvider && provider.getUrl() === url);
 
       if (list.length) {
@@ -79,7 +80,7 @@ class GeoPackageImportUI extends AbstractImportUI {
     provider.load();
 
     os.settings.set(['userProviders', provider.getId()], conf);
-    os.dataManager.addProvider(provider);
+    DataManager.getInstance().addProvider(provider);
 
     AlertManager.getInstance().sendAlert(`${file.getFileName()} GeoPackage added!`, AlertEventSeverity.INFO);
 

--- a/src/plugin/geopackage/geopackageplugin.js
+++ b/src/plugin/geopackage/geopackageplugin.js
@@ -59,7 +59,7 @@ class GeoPackagePlugin extends AbstractPlugin {
     im.registerImportDetails('GeoPackage', true);
     im.registerImportUI(mime.TYPE, new GeoPackageImportUI);
 
-    os.dataManager.listen(DataProviderEventType.REMOVE_PROVIDER, this.onProviderRemove_, false, this);
+    dm.listen(DataProviderEventType.REMOVE_PROVIDER, this.onProviderRemove_, false, this);
   }
 
   /**

--- a/src/plugin/geopackage/geopackageprovider.js
+++ b/src/plugin/geopackage/geopackageprovider.js
@@ -9,6 +9,7 @@ const {makeSafe, intAwareCompare} = goog.require('goog.string');
 const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
 const AlertManager = goog.require('os.alert.AlertManager');
 const ConfigDescriptor = goog.require('os.data.ConfigDescriptor');
+const DataManager = goog.require('os.data.DataManager');
 const {isFileSystem} = goog.require('os.file');
 const LayerType = goog.require('os.layer.LayerType');
 const Request = goog.require('os.net.Request');
@@ -262,13 +263,15 @@ class GeoPackageProvider extends AbstractLoadingServer {
     }
 
     if (id) {
-      let descriptor = /** @type {ConfigDescriptor} */ (os.dataManager.getDescriptor(id));
+      const dataManager = DataManager.getInstance();
+
+      let descriptor = /** @type {ConfigDescriptor} */ (dataManager.getDescriptor(id));
       if (!descriptor) {
         descriptor = new ConfigDescriptor();
       }
 
       descriptor.setBaseConfig(config);
-      os.dataManager.addDescriptor(descriptor);
+      dataManager.addDescriptor(descriptor);
       descriptor.updateActiveFromTemp();
 
       const node = new DescriptorNode();

--- a/test/plugin/geopackage/geopackage.mock.js
+++ b/test/plugin/geopackage/geopackage.mock.js
@@ -1,0 +1,26 @@
+goog.module('plugin.geopackage.mock');
+
+const Settings = goog.require('os.config.Settings');
+const SettingsObjectStorage = goog.require('os.config.storage.SettingsObjectStorage');
+const ExtDomainHandler = goog.require('os.net.ExtDomainHandler');
+const RequestHandlerFactory = goog.require('os.net.RequestHandlerFactory');
+const SameDomainHandler = goog.require('os.net.SameDomainHandler');
+
+const SettingsUtil = goog.require('test.os.config.SettingsUtil');
+
+beforeEach(() => {
+  // Initialize settings
+  const settings = Settings.getInstance();
+  if (!settings.isLoaded() || !settings.isInitialized()) {
+    settings.getStorageRegistry().addStorage(new SettingsObjectStorage(['unit']));
+    SettingsUtil.initAndLoad(settings);
+
+    waitsFor(function() {
+      return settings.isLoaded() && settings.isInitialized();
+    });
+  }
+
+  // Register request handlers
+  RequestHandlerFactory.addHandler(ExtDomainHandler);
+  RequestHandlerFactory.addHandler(SameDomainHandler);
+});

--- a/test/plugin/geopackage/geopackageplugin.test.js
+++ b/test/plugin/geopackage/geopackageplugin.test.js
@@ -1,6 +1,5 @@
-// os.mock sets up a bunch of basic opensphere APIs, like settings, which are used in our plugin
-goog.require('os.mock');
 goog.require('plugin.geopackage.GeoPackagePlugin');
+goog.require('plugin.geopackage.mock');
 
 describe('plugin.geopackage.GeoPackagePlugin', function() {
   const GeoPackagePlugin = goog.module.get('plugin.geopackage.GeoPackagePlugin');


### PR DESCRIPTION
- Updated the local file url enabled API that changed in ngageoint/opensphere/pull/1335. Tests will fail on this until that PR is merged.
- OpenSphere dependency changes introduced a new vendor library requirement (`markdownit`, used by the TUI editor via feature edit) if `os.MapContainer` was required. This was being introduced to GPKG tests by `os.mock.js`, which does way more than these tests need. I made a local mock that only initializes settings and net handlers.
- Replaced `os.dataManager` with `DataManager.getInstance()`, which will be the preferred approach moving forward.