### PR TITLE
fix(columns): filters out empty geometry column

### DIFF
--- a/src/plugin/geopackage/geopackageexporter.js
+++ b/src/plugin/geopackage/geopackageexporter.js
@@ -46,6 +46,19 @@ const LOGGER = log.getLogger('plugin.geopackage.Exporter');
 
 
 /**
+ * Maps a column definition to an exportable column object.
+ * @param {ColumnDefinition} colDef
+ * @return {{field: string, type: string}}
+ */
+const mapColumnDefToColumn = (colDef) => {
+  return {
+    'field': colDef.field,
+    'type': colDef.type
+  };
+};
+
+
+/**
  * The GeoPackage exporter.
  * @extends {AbstractExporter<Feature>}
  */
@@ -264,7 +277,7 @@ class Exporter extends AbstractExporter {
         id: this.lastId,
         type: MsgType.EXPORT,
         command: ExportCommands.CREATE_TABLE,
-        columns: source.getColumns().map(Exporter.mapColumnDefToColumn),
+        columns: source.getColumns().map(mapColumnDefToColumn),
         tableName: tableName
       }));
       return;
@@ -310,17 +323,6 @@ class Exporter extends AbstractExporter {
     }
 
     return null;
-  }
-
-  /**
-   * @param {ColumnDefinition} colDef
-   * @return {{field: string, type: string}}
-   */
-  static mapColumnDefToColumn(colDef) {
-    return {
-      'field': colDef.field,
-      'type': colDef.type
-    };
   }
 }
 

--- a/src/plugin/geopackage/geopackagevectorlayerconfig.js
+++ b/src/plugin/geopackage/geopackagevectorlayerconfig.js
@@ -33,8 +33,16 @@ class VectorLayerConfig extends GeoJSONLayerConfig {
   getLayer(source, options) {
     const layer = super.getLayer(source, options);
 
-    const featureType = new FeatureType(/** @type {string} */ (options['id']),
-        /** @type {Array<!FeatureTypeColumn>} */ (options['dbColumns']));
+    const id = /** @type {string} */ (options['id']);
+    const columns = /** @type {Array<!FeatureTypeColumn>} */ (options['dbColumns'].slice());
+    const featureType = new FeatureType(id, columns);
+
+    if (columns.find((col) => col['name'] == 'geometry')) {
+      // GPKG treats the geometry column as a special field that contains geometry blobs, but we can't show them.
+      // Set the geometry column name to filter that column out in the fixFeatureTypeColumns call below.
+      featureType.setGeometryColumnName('geometry');
+    }
+
     this.fixFeatureTypeColumns(layer, options, featureType);
     this.addMappings(layer, options, featureType);
 


### PR DESCRIPTION
The geometry column seems to be treated special by Geopackages and contains blob data that doesn't display nicely. This filters it out of the source columns in the same way we do with geometry columns in other feature layers.