### PR TITLE
fix(tiles): enables and fixes tile world wrapping

### DIFF
--- a/src/plugin/geopackage/geopackagetilelayerconfig.js
+++ b/src/plugin/geopackage/geopackagetilelayerconfig.js
@@ -85,7 +85,7 @@ class TileLayerConfig extends AbstractTileLayerConfig {
       'tileLoadFunction': getTileLoadFunction(parts[0], gpkgTileGrid, layerTileGrid),
       'tileUrlFunction': getTileUrlFunction(parts[1]),
       'tileGrid': layerTileGrid,
-      'wrapX': false // TODO: fix wrapping tiles crashing and displaying incorrectly outside the world extent
+      'wrapX': true
     }));
 
     source.setExtent(options.extent);


### PR DESCRIPTION
Reenables world wrapping in the layer config for geopackage tile layers and fixes them loading by normalizing the coordinates that we send to the library to request the tiles.