### PR TITLE
refactor(es): transform to es modules and convert default exports

### DIFF
--- a/src/plugin/geopackage/geopackage.js
+++ b/src/plugin/geopackage/geopackage.js
@@ -1,4 +1,4 @@
-goog.module('plugin.geopackage');
+goog.declareModuleId('plugin.geopackage');
 
 const log = goog.require('goog.log');
 
@@ -8,23 +8,22 @@ const Logger = goog.requireType('goog.log.Logger');
 /**
  * @define {string}
  */
-exports.ROOT = goog.define('plugin.geopackage.ROOT', '../opensphere-plugin-geopackage/');
+export const ROOT = goog.define('plugin.geopackage.ROOT', '../opensphere-plugin-geopackage/');
 
 /**
  * @define {string}
  */
-exports.GPKG_PATH = goog.define('plugin.geopackage.GPKG_PATH', 'vendor/geopackage/geopackage.min.js');
+export const GPKG_PATH = goog.define('plugin.geopackage.GPKG_PATH', 'vendor/geopackage/geopackage.min.js');
 
 /**
  * @type {string}
  * @const
  */
-exports.ID = 'geopackage';
+export const ID = 'geopackage';
 
 
 /**
  * The logger.
- * @const
  * @type {Logger}
  */
 const LOGGER = log.getLogger('plugin.geopackage');
@@ -33,7 +32,7 @@ const LOGGER = log.getLogger('plugin.geopackage');
 /**
  * @enum {string}
  */
-exports.MsgType = {
+export const MsgType = {
   OPEN_LIBRARY: 'openLibrary',
   OPEN: 'open',
   CLOSE: 'close',
@@ -48,7 +47,7 @@ exports.MsgType = {
 /**
  * @enum {string}
  */
-exports.ExportCommands = {
+export const ExportCommands = {
   CREATE: 'create',
   CREATE_TABLE: 'createTable',
   GEOJSON: 'geojson',
@@ -62,14 +61,14 @@ exports.ExportCommands = {
 /**
  * @type {?Worker}
  */
-let worker_ = null;
+let worker = null;
 
 
 /**
  * Get the Electron preload exports.
  * @return {Object|undefined}
  */
-exports.getElectron = () => {
+export const getElectron = () => {
   return window.ElectronGpkg || undefined;
 };
 
@@ -78,19 +77,19 @@ exports.getElectron = () => {
  * If the app is running within Electron.
  * @return {boolean}
  */
-exports.isElectron = () => {
-  return !!exports.getElectron();
+export const isElectron = () => {
+  return !!getElectron();
 };
 
 
 /**
  * @return {!Worker} The GeoPackage worker
  */
-exports.getWorker = () => {
-  if (!worker_) {
-    let src = exports.ROOT + 'src/worker/gpkg.worker.js';
+export const getWorker = () => {
+  if (!worker) {
+    let src = ROOT + 'src/worker/gpkg.worker.js';
 
-    const electron = exports.getElectron();
+    const electron = getElectron();
     if (electron) {
       // The node context (as opposed to the electron browser context), loads
       // paths relative to process.cwd(). Therefore, we need to make our source
@@ -121,18 +120,18 @@ exports.getWorker = () => {
       // DEBUG VERSION! Do not commit next line uncommented
       // options['execArgv'] = ['--inspect-brk'];
 
-      worker_ = (electron.forkProcess(src, [], options));
+      worker = (electron.forkProcess(src, [], options));
 
       log.info(LOGGER, 'GeoPackage worker configured via node child process');
     } else {
-      worker_ = new Worker(src);
-      worker_.postMessage(/** @type {GeoPackageWorkerMessage} */ ({
-        type: exports.MsgType.OPEN_LIBRARY,
-        url: (!exports.GPKG_PATH.startsWith('/') ? '../../' : '') + exports.GPKG_PATH
+      worker = new Worker(src);
+      worker.postMessage(/** @type {GeoPackageWorkerMessage} */ ({
+        type: MsgType.OPEN_LIBRARY,
+        url: (!GPKG_PATH.startsWith('/') ? '../../' : '') + GPKG_PATH
       }));
       log.info(LOGGER, 'GeoPackage worker configured via web worker');
     }
   }
 
-  return worker_;
+  return worker;
 };

--- a/src/plugin/geopackage/geopackageexporter.js
+++ b/src/plugin/geopackage/geopackageexporter.js
@@ -1,4 +1,7 @@
-goog.module('plugin.geopackage.Exporter');
+goog.declareModuleId('plugin.geopackage.Exporter');
+
+import {PROJECTION} from 'opensphere/src/os/map/map.js';
+import {getElectron, getWorker, ExportCommands, MsgType} from './geopackage.js';
 
 const {bucket} = goog.require('goog.array');
 const GoogEventType = goog.require('goog.events.EventType');
@@ -10,11 +13,9 @@ const DataManager = goog.require('os.data.DataManager');
 const RecordField = goog.require('os.data.RecordField');
 const OSEventType = goog.require('os.events.EventType');
 const AbstractExporter = goog.require('os.ex.AbstractExporter');
-const osMap = goog.require('os.map');
 const {getMapContainer} = goog.require('os.map.instance');
 const {EPSG4326} = goog.require('os.proj');
 const ThreadProgressEvent = goog.require('os.thread.ThreadProgressEvent');
-const {getElectron, getWorker, ExportCommands, MsgType} = goog.require('plugin.geopackage');
 
 const Feature = goog.requireType('ol.Feature');
 const ColumnDefinition = goog.requireType('os.data.ColumnDefinition');
@@ -64,7 +65,7 @@ const mapColumnDefToColumn = (colDef) => {
  * The GeoPackage exporter.
  * @extends {AbstractExporter<Feature>}
  */
-class Exporter extends AbstractExporter {
+export class Exporter extends AbstractExporter {
   /**
    * Constructor.
    */
@@ -325,7 +326,7 @@ class Exporter extends AbstractExporter {
     const worker = getWorker();
 
     const geojson = this.format.writeFeaturesObject(features, {
-      featureProjection: osMap.PROJECTION,
+      featureProjection: PROJECTION,
       dataProjection: EPSG4326,
       fields: this.fields
     });
@@ -374,6 +375,3 @@ class Exporter extends AbstractExporter {
     return null;
   }
 }
-
-
-exports = Exporter;

--- a/src/plugin/geopackage/geopackageimportui.js
+++ b/src/plugin/geopackage/geopackageimportui.js
@@ -1,4 +1,7 @@
-goog.module('plugin.geopackage.GeoPackageImportUI');
+goog.declareModuleId('plugin.geopackage.GeoPackageImportUI');
+
+import {ID} from './geopackage.js';
+import {GeoPackageProvider} from './geopackageprovider.js';
 
 const AbstractImportUI = goog.require('os.ui.im.AbstractImportUI');
 const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
@@ -7,9 +10,7 @@ const Settings = goog.require('os.config.Settings');
 const DataManager = goog.require('os.data.DataManager');
 const DataProviderEventType = goog.require('os.data.DataProviderEventType');
 const FileStorage = goog.require('os.file.FileStorage');
-const GeoPackageProvider = goog.require('plugin.geopackage.GeoPackageProvider');
 const OSFile = goog.requireType('os.file.File');
-const geopackage = goog.require('plugin.geopackage');
 const windows = goog.require('os.ui.menu.windows');
 const {isLocal, isFileUrlEnabled} = goog.require('os.file');
 
@@ -19,7 +20,7 @@ const DescriptorNode = goog.requireType('os.ui.data.DescriptorNode');
 
 /**
  */
-class GeoPackageImportUI extends AbstractImportUI {
+export class GeoPackageImportUI extends AbstractImportUI {
   /**
    * Constructor.
    */
@@ -69,7 +70,7 @@ class GeoPackageImportUI extends AbstractImportUI {
   onFileReady(opt_config) {
     const file = this.file;
     const conf = {
-      'type': geopackage.ID,
+      'type': ID,
       'label': file.getFileName(),
       'url': file.getUrl()
     };
@@ -119,5 +120,3 @@ class GeoPackageImportUI extends AbstractImportUI {
     }
   }
 }
-
-exports = GeoPackageImportUI;

--- a/src/plugin/geopackage/geopackageplugin.js
+++ b/src/plugin/geopackage/geopackageplugin.js
@@ -1,4 +1,13 @@
-goog.module('plugin.geopackage.GeoPackagePlugin');
+goog.declareModuleId('plugin.geopackage.GeoPackagePlugin');
+
+import {ID} from './geopackage.js';
+import {Exporter} from './geopackageexporter.js';
+import {GeoPackageImportUI} from './geopackageimportui.js';
+import {GeoPackageProvider} from './geopackageprovider.js';
+import {RequestHandler} from './geopackagerequesthandler.js';
+import {TileLayerConfig} from './geopackagetilelayerconfig.js';
+import {VectorLayerConfig} from './geopackagevectorlayerconfig.js';
+import {TYPE} from './mime.js';
 
 const DataManager = goog.require('os.data.DataManager');
 const DataProviderEventType = goog.require('os.data.DataProviderEventType');
@@ -11,26 +20,18 @@ const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const PluginManager = goog.require('os.plugin.PluginManager');
 const ImportManager = goog.require('os.ui.im.ImportManager');
 const exportManager = goog.require('os.ui.exportManager');
-const geopackage = goog.require('plugin.geopackage');
-const Exporter = goog.require('plugin.geopackage.Exporter');
-const GeoPackageImportUI = goog.require('plugin.geopackage.GeoPackageImportUI');
-const GeoPackageProvider = goog.require('plugin.geopackage.GeoPackageProvider');
-const RequestHandler = goog.require('plugin.geopackage.RequestHandler');
-const TileLayerConfig = goog.require('plugin.geopackage.TileLayerConfig');
-const VectorLayerConfig = goog.require('plugin.geopackage.VectorLayerConfig');
-const mime = goog.require('plugin.geopackage.mime');
 
 
 /**
  * Provides support for GeoPackage vector files
  */
-class GeoPackagePlugin extends AbstractPlugin {
+export class GeoPackagePlugin extends AbstractPlugin {
   /**
    * Constructor.
    */
   constructor() {
     super();
-    this.id = geopackage.ID;
+    this.id = ID;
     this.errorMessage = null;
   }
 
@@ -41,14 +42,14 @@ class GeoPackagePlugin extends AbstractPlugin {
     // register geopackage provider type
     const dm = DataManager.getInstance();
     dm.registerProviderType(new ProviderEntry(
-        geopackage.ID,
+        ID,
         GeoPackageProvider,
         'GeoPackage File',
         'Provides raster and vector data in a single file format'));
 
     const lcm = LayerConfigManager.getInstance();
-    lcm.registerLayerConfig(geopackage.ID + '-tile', TileLayerConfig);
-    lcm.registerLayerConfig(geopackage.ID + '-vector', VectorLayerConfig);
+    lcm.registerLayerConfig(ID + '-tile', TileLayerConfig);
+    lcm.registerLayerConfig(ID + '-vector', VectorLayerConfig);
 
     RequestHandlerFactory.addHandler(RequestHandler);
 
@@ -57,7 +58,7 @@ class GeoPackagePlugin extends AbstractPlugin {
 
     const im = ImportManager.getInstance();
     im.registerImportDetails('GeoPackage', true);
-    im.registerImportUI(mime.TYPE, new GeoPackageImportUI);
+    im.registerImportUI(TYPE, new GeoPackageImportUI);
 
     dm.listen(DataProviderEventType.REMOVE_PROVIDER, this.onProviderRemove_, false, this);
   }
@@ -78,5 +79,3 @@ class GeoPackagePlugin extends AbstractPlugin {
 
 // add the plugin to the application
 PluginManager.getInstance().addPlugin(new GeoPackagePlugin());
-
-exports = GeoPackagePlugin;

--- a/src/plugin/geopackage/geopackageprovider.js
+++ b/src/plugin/geopackage/geopackageprovider.js
@@ -1,4 +1,7 @@
-goog.module('plugin.geopackage.GeoPackageProvider');
+goog.declareModuleId('plugin.geopackage.GeoPackageProvider');
+
+import {getWorker, isElectron, MsgType, ID} from './geopackage.js';
+import {MIN_ZOOM, MAX_ZOOM} from 'opensphere/src/os/map/map.js';
 
 const GoogEventType = goog.require('goog.events.EventType');
 const log = goog.require('goog.log');
@@ -18,8 +21,6 @@ const BaseProvider = goog.require('os.ui.data.BaseProvider');
 const DescriptorNode = goog.require('os.ui.data.DescriptorNode');
 const {directiveTag} = goog.require('os.ui.data.LayerCheckboxUI');
 const AbstractLoadingServer = goog.require('os.ui.server.AbstractLoadingServer');
-const {getWorker, isElectron, MsgType, ID} = goog.require('plugin.geopackage');
-const {MIN_ZOOM, MAX_ZOOM} = goog.require('os.map');
 
 const GoogEvent = goog.requireType('goog.events.Event');
 const ITreeNode = goog.requireType('os.structs.ITreeNode');
@@ -43,7 +44,7 @@ const labelSort = (a, b) => intAwareCompare(a.getLabel() || '', b.getLabel() || 
 /**
  * GeoPackage provider
  */
-class GeoPackageProvider extends AbstractLoadingServer {
+export class GeoPackageProvider extends AbstractLoadingServer {
   /**
    * Constructor.
    */
@@ -281,5 +282,3 @@ class GeoPackageProvider extends AbstractLoadingServer {
     }
   }
 }
-
-exports = GeoPackageProvider;

--- a/src/plugin/geopackage/geopackagerequesthandler.js
+++ b/src/plugin/geopackage/geopackagerequesthandler.js
@@ -1,10 +1,11 @@
-goog.module('plugin.geopackage.RequestHandler');
+goog.declareModuleId('plugin.geopackage.RequestHandler');
+
+import {getWorker, MsgType, ID} from './geopackage.js';
 
 const EventTarget = goog.require('goog.events.EventTarget');
 const GoogEventType = goog.require('goog.events.EventType');
 const log = goog.require('goog.log');
 const NetEventType = goog.require('goog.net.EventType');
-const {getWorker, MsgType, ID} = goog.require('plugin.geopackage');
 
 const Logger = goog.requireType('goog.log.Logger');
 const IRequestHandler = goog.requireType('os.net.IRequestHandler');
@@ -20,7 +21,7 @@ const LOGGER = log.getLogger('plugin.geopackage.RequestHandler');
 /**
  * @implements {IRequestHandler}
  */
-class RequestHandler extends EventTarget {
+export class RequestHandler extends EventTarget {
   /**
    * Constructor.
    */
@@ -208,6 +209,3 @@ class RequestHandler extends EventTarget {
     }
   }
 }
-
-
-exports = RequestHandler;

--- a/src/plugin/geopackage/geopackagetile.js
+++ b/src/plugin/geopackage/geopackagetile.js
@@ -1,4 +1,4 @@
-goog.module('plugin.geopackage.Tile');
+goog.declareModuleId('plugin.geopackage.Tile');
 
 const ColorableTile = goog.require('os.tile.ColorableTile');
 
@@ -6,7 +6,7 @@ const ColorableTile = goog.require('os.tile.ColorableTile');
 /**
  * Implementation of a tile that is colorable.
  */
-class Tile extends ColorableTile {
+export class Tile extends ColorableTile {
   /**
    * Constructor.
    * @param {ol.TileCoord} tileCoord Tile coordinate.
@@ -31,5 +31,3 @@ class Tile extends ColorableTile {
     super.disposeInternal();
   }
 }
-
-exports = Tile;

--- a/src/plugin/geopackage/geopackagetilelayerconfig.js
+++ b/src/plugin/geopackage/geopackagetilelayerconfig.js
@@ -1,4 +1,8 @@
-goog.module('plugin.geopackage.TileLayerConfig');
+goog.declareModuleId('plugin.geopackage.TileLayerConfig');
+
+import {PROJECTION} from 'opensphere/src/os/map/map.js';
+import {MsgType, getWorker} from './geopackage.js';
+import {Tile} from './geopackagetile.js';
 
 const GoogEventType = goog.require('goog.events.EventType');
 const log = goog.require('goog.log');
@@ -9,12 +13,9 @@ const {transformExtent} = goog.require('ol.proj');
 const TileImage = goog.require('ol.source.TileImage');
 const {createForProjection} = goog.require('ol.tilegrid');
 const TileGrid = goog.require('ol.tilegrid.TileGrid');
-const osMap = goog.require('os.map');
 const {EPSG4326} = goog.require('os.proj');
 const AbstractTileLayerConfig = goog.require('os.layer.config.AbstractTileLayerConfig');
 const BaseProvider = goog.require('os.ui.data.BaseProvider');
-const {MsgType, getWorker} = goog.require('plugin.geopackage');
-const Tile = goog.require('plugin.geopackage.Tile');
 
 const Projection = goog.requireType('ol.proj.Projection');
 
@@ -41,7 +42,7 @@ const tiles = {};
 /**
  * Creates a tile layer from a GeoPackage.
  */
-class TileLayerConfig extends AbstractTileLayerConfig {
+export class TileLayerConfig extends AbstractTileLayerConfig {
   /**
    * Constructor.
    */
@@ -78,7 +79,7 @@ class TileLayerConfig extends AbstractTileLayerConfig {
       'tileSizes': options['tileSizes']
     }));
 
-    const layerTileGrid = createForProjection(osMap.PROJECTION, DEFAULT_MAX_ZOOM, [256, 256]);
+    const layerTileGrid = createForProjection(PROJECTION, DEFAULT_MAX_ZOOM, [256, 256]);
 
     const source = new TileImage(/** @type {olx.source.TileImageOptions} */ ({
       'projection': this.projection,
@@ -117,7 +118,7 @@ const getTileLoadFunction = (providerId, gpkgTileGrid, tileGrid) => (
     if (layerName) {
       const tileCoord = imageTile.getTileCoord();
       let extent = tileGrid.getTileCoordExtent(tileCoord);
-      extent = transformExtent(extent, osMap.PROJECTION, EPSG4326);
+      extent = transformExtent(extent, PROJECTION, EPSG4326);
       const layerResolution = tileGrid.getResolution(tileCoord[0]);
       const gpkgZoom = gpkgTileGrid.getZForResolution(layerResolution);
       const size = tileGrid.getTileSize(tileCoord[0]);
@@ -126,7 +127,7 @@ const getTileLoadFunction = (providerId, gpkgTileGrid, tileGrid) => (
         id: providerId,
         type: MsgType.GET_TILE,
         tableName: layerName,
-        projection: osMap.PROJECTION.getCode(),
+        projection: PROJECTION.getCode(),
         extent: extent,
         zoom: gpkgZoom,
         width: size[0],
@@ -206,5 +207,3 @@ const getTileUrlFunction = (layerName) => (
    */
   (tileCoord, pixelRatio, projection) => layerName
 );
-
-exports = TileLayerConfig;

--- a/src/plugin/geopackage/geopackagevectorlayerconfig.js
+++ b/src/plugin/geopackage/geopackagevectorlayerconfig.js
@@ -1,4 +1,4 @@
-goog.module('plugin.geopackage.VectorLayerConfig');
+goog.declareModuleId('plugin.geopackage.VectorLayerConfig');
 
 const AltMapping = goog.require('os.im.mapping.AltMapping');
 const RadiusMapping = goog.require('os.im.mapping.RadiusMapping');
@@ -19,7 +19,7 @@ const Request = goog.requireType('os.source.Request');
 
 /**
  */
-class VectorLayerConfig extends GeoJSONLayerConfig {
+export class VectorLayerConfig extends GeoJSONLayerConfig {
   /**
    * Constructor.
    */
@@ -100,5 +100,3 @@ class VectorLayerConfig extends GeoJSONLayerConfig {
     ]);
   }
 }
-
-exports = VectorLayerConfig;

--- a/src/plugin/geopackage/mime.js
+++ b/src/plugin/geopackage/mime.js
@@ -1,17 +1,15 @@
-goog.module('plugin.geopackage.mime');
+goog.declareModuleId('plugin.geopackage.mime');
 
 const Promise = goog.require('goog.Promise');
-const mime = goog.require('os.file.mime');
+const {register} = goog.require('os.file.mime');
 
 const OSFile = goog.requireType('os.file.File');
 
 
 /**
  * @type {string}
- * @const
  */
-exports.TYPE = 'application/vnd.opengeospatial.geopackage+sqlite3';
-
+export const TYPE = 'application/vnd.opengeospatial.geopackage+sqlite3';
 
 /**
  * @param {ArrayBuffer} buffer
@@ -19,7 +17,7 @@ exports.TYPE = 'application/vnd.opengeospatial.geopackage+sqlite3';
  * @param {*=} opt_context
  * @return {!Promise<*|undefined>}
  */
-exports.detect = (buffer, file, opt_context) => {
+export const detect = (buffer, file, opt_context) => {
   let retVal = false;
 
   const str = 'SQLite format 3';
@@ -32,5 +30,4 @@ exports.detect = (buffer, file, opt_context) => {
   return /** @type {!Promise<*|undefined>} */ (Promise.resolve(retVal));
 };
 
-
-mime.register(exports.TYPE, exports.detect);
+register(TYPE, detect);

--- a/test/plugin/geopackage/geopackageplugin.test.js
+++ b/test/plugin/geopackage/geopackageplugin.test.js
@@ -2,7 +2,7 @@ goog.require('plugin.geopackage.GeoPackagePlugin');
 goog.require('plugin.geopackage.mock');
 
 describe('plugin.geopackage.GeoPackagePlugin', function() {
-  const GeoPackagePlugin = goog.module.get('plugin.geopackage.GeoPackagePlugin');
+  const {GeoPackagePlugin} = goog.module.get('plugin.geopackage.GeoPackagePlugin');
 
   it('should have the proper ID', function() {
     expect(new GeoPackagePlugin().id).toBe('geopackage');

--- a/test/plugin/geopackage/geopackageprovider.test.js
+++ b/test/plugin/geopackage/geopackageprovider.test.js
@@ -2,7 +2,7 @@ goog.require('plugin.geopackage.GeoPackageProvider');
 
 
 describe('plugin.geopackage.GeoPackageProvider', function() {
-  const GeoPackageProvider = goog.module.get('plugin.geopackage.GeoPackageProvider');
+  const {GeoPackageProvider} = goog.module.get('plugin.geopackage.GeoPackageProvider');
 
   const baseUrl = '/base/test/resources/geopackage/';
 


### PR DESCRIPTION
Converts all files from `goog.module` to ES modules.

Following the [Google JS style guide](https://google.github.io/styleguide/jsguide.html#es-module-exports), this also converts all default exports to named exports. The main drive behind this is to help enforce consistent import naming between modules.