### PR TITLE
refactor(import): replace parent relative imports and sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@semantic-release/release-notes-generator": "^7.1.4",
     "angular-mocks": "~1.8.x",
     "eslint": "^7.26.0",
-    "eslint-config-opensphere": "^5.0.0",
+    "eslint-config-opensphere": "^6.0.2",
     "husky": "^3.0.2",
     "karma": "^4.3.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/src/plugin/geopackage/geopackageprovider.js
+++ b/src/plugin/geopackage/geopackageprovider.js
@@ -1,7 +1,7 @@
 goog.declareModuleId('plugin.geopackage.GeoPackageProvider');
 
-import {getWorker, isElectron, MsgType, ID} from './geopackage.js';
-import {MIN_ZOOM, MAX_ZOOM} from 'opensphere/src/os/map/map.js';
+import {MAX_ZOOM, MIN_ZOOM} from 'opensphere/src/os/map/map.js';
+import {ID, MsgType, getWorker, isElectron} from './geopackage.js';
 
 const GoogEventType = goog.require('goog.events.EventType');
 const log = goog.require('goog.log');


### PR DESCRIPTION
- Relative parent imports (using `../`) have been replaced with module-relative imports.
- Import statements have been sorted by group (external -> internal -> relative sibling) and alphabetically by path within each group.