### PR TITLE
refactor(es): convert requires to imports

### DIFF
--- a/src/plugin/geopackage/geopackagevectorlayerconfig.js
+++ b/src/plugin/geopackage/geopackagevectorlayerconfig.js
@@ -1,5 +1,7 @@
 goog.declareModuleId('plugin.geopackage.VectorLayerConfig');
 
+import GeoJSONLayerConfig from 'opensphere/src/plugin/file/geojson/geojsonlayerconfig.js';
+
 const AltMapping = goog.require('os.im.mapping.AltMapping');
 const RadiusMapping = goog.require('os.im.mapping.RadiusMapping');
 const SemiMajorMapping = goog.require('os.im.mapping.SemiMajorMapping');
@@ -8,7 +10,6 @@ const TimeFormat = goog.require('os.im.mapping.TimeFormat');
 const TimeType = goog.require('os.im.mapping.TimeType');
 const DateTimeMapping = goog.require('os.im.mapping.time.DateTimeMapping');
 const FeatureType = goog.require('os.ogc.wfs.FeatureType');
-const GeoJSONLayerConfig = goog.require('plugin.file.geojson.GeoJSONLayerConfig');
 
 const Importer = goog.requireType('os.im.Importer');
 const VectorLayer = goog.requireType('os.layer.Vector');


### PR DESCRIPTION
Converted requires to imports for modules updated in ngageoint/opensphere/pull/1363. This was fully scripted.

The build for this will fail until the OpenSphere PR is merged.