### PR TITLE
refactor(es): convert requires to imports

### DIFF
--- a/src/plugin/geopackage/geopackageimportui.js
+++ b/src/plugin/geopackage/geopackageimportui.js
@@ -1,21 +1,22 @@
 goog.declareModuleId('plugin.geopackage.GeoPackageImportUI');
 
+import AbstractImportUI from 'opensphere/src/os/ui/im/abstractimportui.js';
+import * as windows from 'opensphere/src/os/ui/menu/windowsmenu.js';
 import {ID} from './geopackage.js';
 import {GeoPackageProvider} from './geopackageprovider.js';
 
-const AbstractImportUI = goog.require('os.ui.im.AbstractImportUI');
 const AlertEventSeverity = goog.require('os.alert.AlertEventSeverity');
 const AlertManager = goog.require('os.alert.AlertManager');
 const Settings = goog.require('os.config.Settings');
 const DataManager = goog.require('os.data.DataManager');
 const DataProviderEventType = goog.require('os.data.DataProviderEventType');
-const FileStorage = goog.require('os.file.FileStorage');
-const OSFile = goog.requireType('os.file.File');
-const windows = goog.require('os.ui.menu.windows');
 const {isLocal, isFileUrlEnabled} = goog.require('os.file');
 
+const FileStorage = goog.require('os.file.FileStorage');
+
 const DataProviderEvent = goog.requireType('os.data.DataProviderEvent');
-const DescriptorNode = goog.requireType('os.ui.data.DescriptorNode');
+const OSFile = goog.requireType('os.file.File');
+const {default: DescriptorNode} = goog.requireType('os.ui.data.DescriptorNode');
 
 
 /**

--- a/src/plugin/geopackage/geopackageplugin.js
+++ b/src/plugin/geopackage/geopackageplugin.js
@@ -1,5 +1,7 @@
 goog.declareModuleId('plugin.geopackage.GeoPackagePlugin');
 
+import exportManager from 'opensphere/src/os/ui/file/uiexportmanager.js';
+import ImportManager from 'opensphere/src/os/ui/im/importmanager.js';
 import {ID} from './geopackage.js';
 import {Exporter} from './geopackageexporter.js';
 import {GeoPackageImportUI} from './geopackageimportui.js';
@@ -18,8 +20,6 @@ const LayerConfigManager = goog.require('os.layer.config.LayerConfigManager');
 const RequestHandlerFactory = goog.require('os.net.RequestHandlerFactory');
 const AbstractPlugin = goog.require('os.plugin.AbstractPlugin');
 const PluginManager = goog.require('os.plugin.PluginManager');
-const ImportManager = goog.require('os.ui.im.ImportManager');
-const exportManager = goog.require('os.ui.exportManager');
 
 
 /**

--- a/src/plugin/geopackage/geopackageprovider.js
+++ b/src/plugin/geopackage/geopackageprovider.js
@@ -1,6 +1,11 @@
 goog.declareModuleId('plugin.geopackage.GeoPackageProvider');
 
 import {MAX_ZOOM, MIN_ZOOM} from 'opensphere/src/os/map/map.js';
+import BaseProvider from 'opensphere/src/os/ui/data/baseprovider.js';
+import DescriptorNode from 'opensphere/src/os/ui/data/descriptornode.js';
+import {directiveTag} from 'opensphere/src/os/ui/data/layercheckbox.js';
+import Icons from 'opensphere/src/os/ui/icons.js';
+import AbstractLoadingServer from 'opensphere/src/os/ui/server/abstractloadingserver.js';
 import {ID, MsgType, getWorker, isElectron} from './geopackage.js';
 
 const GoogEventType = goog.require('goog.events.EventType');
@@ -16,11 +21,6 @@ const DataManager = goog.require('os.data.DataManager');
 const {isFileSystem} = goog.require('os.file');
 const LayerType = goog.require('os.layer.LayerType');
 const Request = goog.require('os.net.Request');
-const Icons = goog.require('os.ui.Icons');
-const BaseProvider = goog.require('os.ui.data.BaseProvider');
-const DescriptorNode = goog.require('os.ui.data.DescriptorNode');
-const {directiveTag} = goog.require('os.ui.data.LayerCheckboxUI');
-const AbstractLoadingServer = goog.require('os.ui.server.AbstractLoadingServer');
 
 const GoogEvent = goog.requireType('goog.events.Event');
 const ITreeNode = goog.requireType('os.structs.ITreeNode');

--- a/src/plugin/geopackage/geopackagetilelayerconfig.js
+++ b/src/plugin/geopackage/geopackagetilelayerconfig.js
@@ -1,6 +1,7 @@
 goog.declareModuleId('plugin.geopackage.TileLayerConfig');
 
 import {PROJECTION} from 'opensphere/src/os/map/map.js';
+import BaseProvider from 'opensphere/src/os/ui/data/baseprovider.js';
 import {MsgType, getWorker} from './geopackage.js';
 import {Tile} from './geopackagetile.js';
 
@@ -13,9 +14,8 @@ const {transformExtent} = goog.require('ol.proj');
 const TileImage = goog.require('ol.source.TileImage');
 const {createForProjection} = goog.require('ol.tilegrid');
 const TileGrid = goog.require('ol.tilegrid.TileGrid');
-const {EPSG4326} = goog.require('os.proj');
 const AbstractTileLayerConfig = goog.require('os.layer.config.AbstractTileLayerConfig');
-const BaseProvider = goog.require('os.ui.data.BaseProvider');
+const {EPSG4326} = goog.require('os.proj');
 
 const Projection = goog.requireType('ol.proj.Projection');
 

--- a/test/plugin/geopackage/geopackageprovider.test.js
+++ b/test/plugin/geopackage/geopackageprovider.test.js
@@ -8,8 +8,8 @@ goog.require('plugin.geopackage.GeoPackageProvider');
 describe('plugin.geopackage.GeoPackageProvider', function() {
   const DataProviderEventType = goog.module.get('os.data.DataProviderEventType');
   const LayerType = goog.module.get('os.layer.LayerType');
-  const Icons = goog.module.get('os.ui.Icons');
-  const BaseProvider = goog.module.get('os.ui.data.BaseProvider');
+  const {default: Icons} = goog.module.get('os.ui.Icons');
+  const {default: BaseProvider} = goog.module.get('os.ui.data.BaseProvider');
   const {GeoPackageProvider} = goog.module.get('plugin.geopackage.GeoPackageProvider');
 
   const baseUrl = '/base/test/resources/geopackage/';


### PR DESCRIPTION
Converted requires to imports for modules updated in ngageoint/opensphere/pull/1364. This was fully scripted.

The build for this will fail until the OpenSphere PR is merged.