### PR TITLE
build(gcc): use latest closure compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@ngageoint/closure-webpack-plugin": "^2.0.0",
+    "@ngageoint/closure-webpack-plugin": "^3.0.0",
     "@ngageoint/opensphere-coverage-loader": "^1.0.0",
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/commit-analyzer": "^6.1.0",
@@ -103,7 +103,7 @@
     "modernizr": "^3.8.0",
     "npm-run-all": "^4.1.5",
     "opensphere-build-closure-helper": "^7.0.0",
-    "opensphere-build-resolver": "^8.0.0",
+    "opensphere-build-resolver": "^10.0.0",
     "rimraf": "^2.5.4",
     "sass-lint": "^1.12.1",
     "semantic-release": "^15.13.32"


### PR DESCRIPTION
Updates the Closure webpack plugin and resolver to use the latest Closure compiler. This is paired with a similar update in OpenSphere, in ngageoint/opensphere/pull/1369.